### PR TITLE
ErrorKind improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,9 +186,8 @@ impl ErrorKind {
     }
 }
 
-#[cfg(not(feature = "nostd"))]
-impl std::fmt::Display for ErrorKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let msg: &str = match self {
             ErrorKind::OOB => "OOB",
             ErrorKind::OOBContext => "OOBContext",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ impl<T: Copy, const N: usize> VectorTrait<T> for HeaplessVec<T, N> {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ErrorKind {
     OOB,
     OOBContext,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,32 +189,6 @@ impl ErrorKind {
 impl core::fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let msg: &str = match self {
-            ErrorKind::OOB => "OOB",
-            ErrorKind::OOBContext => "OOBContext",
-            ErrorKind::FrameBroken => "FrameBroken",
-            ErrorKind::FrameCRCError => "FrameCRCError",
-            ErrorKind::IllegalFunction => "IllegalFunction",
-            ErrorKind::IllegalDataAddress => "IllegalDataAddress",
-            ErrorKind::IllegalDataValue => "IllegalDataValue",
-            ErrorKind::SlaveDeviceFailure => "SlaveDeviceFailure",
-            ErrorKind::Acknowledge => "Acknowledge",
-            ErrorKind::SlaveDeviceBusy => "SlaveDeviceBusy",
-            ErrorKind::NegativeAcknowledge => "NegativeAcknowledge",
-            ErrorKind::MemoryParityError => "MemoryParityError",
-            ErrorKind::GatewayPathUnavailable => "GatewayPathUnavailable",
-            ErrorKind::GatewayTargetFailed => "GatewayTargetFailed",
-            ErrorKind::CommunicationError => "CommunicationError",
-            ErrorKind::UnknownError => "UnknownError",
-            ErrorKind::Utf8Error => "Utf8Error",
-        };
-        write!(f, "{}", msg)
-    } // fn fmt
-} // impl std::fmt::Display
-
-#[cfg(not(feature = "nostd"))]
-impl std::error::Error for ErrorKind {
-    fn description(&self) -> &str {
-        match self {
             ErrorKind::OOB => "OUT OF BUFFER",
             ErrorKind::OOBContext => "OUT OF BUFFER IN CONTEXT",
             ErrorKind::FrameBroken => "FRAME BROKEN",
@@ -236,9 +210,13 @@ impl std::error::Error for ErrorKind {
             }
             ErrorKind::UnknownError => "UNKNOWN MODBUS ERROR",
             ErrorKind::Utf8Error => "UTF8 CONVERTION ERROR",
-        }
-    } // fn description
-} // impl std::error::Error
+        };
+        write!(f, "{}", msg)
+    }
+}
+
+#[cfg(not(feature = "nostd"))]
+impl std::error::Error for ErrorKind {}
 
 pub const MODBUS_GET_COILS: u8 = 1;
 pub const MODBUS_GET_DISCRETES: u8 = 2;


### PR DESCRIPTION
Hi, three changes to the `ErrorKind` type here:

1. The `fmt::Display` trait is availabe in libcore and thus does not depend on libstd at all.  Provide the implementation in the `no_std` build as well.
2. Remove the `Error::description()` implementation as that method is deprecated [^1] and only the `Display` impl should be used.
   Because of this, move the descriptive strings into the `Display` impl instead.  The "bare variant strings" which were in there previously are still available through the `Debug` impl anyway.
3. Implement `Clone` and `Copy` for `ErrorKind`

[^1]: https://doc.rust-lang.org/std/error/trait.Error.html#method.description