### PR TITLE
make new a const fn

### DIFF
--- a/src/server/context.rs
+++ b/src/server/context.rs
@@ -243,7 +243,7 @@ impl<const C: usize, const D: usize, const I: usize, const H: usize> ModbusConte
     /// let context = ModbusContext::<128, 16, 0, 100>::new();
     /// ```
     #[inline]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             coils: [false; C],
             discretes: [false; D],


### PR DESCRIPTION
This allows use of the constructor inside a global static. More specifically, it allows this to work:

```rust
static mut MODBUS_CONTEXT: Mutex<ModbusContext<0, 0, 0, 10>> =
    Mutex::new(ModbusContext::<0, 0, 0, 10>::new());
```