### PR TITLE
support vector in core alloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ default = ["std"]
 std = []
 with_serde = ["serde", "serde_arrays"]
 with_bincode = ["bincode"]
+# Provide impls for types in the Rust core allocation and collections library
+# including String, Box<T>, Vec<T>, and Cow<T>. This is a subset of std but may
+# be enabled without depending on all of std.
+alloc = []
 
 [dev-dependencies]
 rand = "0.7.3"

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Some of rmodbus functions use vectors to store result.  Different vector types c
 - With the `fixedvec` feature, [`fixedvec::FixedVec`](https://crates.io/crates/fixedvec) can be used.
 - With the `heapless` feature, [`heapless::Vec`](https://crates.io/crates/fixedvec) can be used.
 
-- when the `std` feature is disable, and without `heapless` feature, and without `fixedvec` feature, no-std `alloc::vec::Vec` can be used.
+- when the `alloc` feature is enable, Rust core allocation `alloc::vec::Vec` can be used in no-std mode. e.g `cargo build --no-default-features --features alloc` will build in no-std mode, and support using core allocation `alloc::vec::Vec`. when `std` feature is enabled, `alloc` feature will be ignored.
 
 ## Modbus client
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Some of rmodbus functions use vectors to store result.  Different vector types c
 - With the `fixedvec` feature, [`fixedvec::FixedVec`](https://crates.io/crates/fixedvec) can be used.
 - With the `heapless` feature, [`heapless::Vec`](https://crates.io/crates/fixedvec) can be used.
 
-- when the `std` feature is disable, and without `heapless` feature, and with `fixedvec` feature, no-std `alloc::vec::Vec` can be used.
+- when the `std` feature is disable, and without `heapless` feature, and without `fixedvec` feature, no-std `alloc::vec::Vec` can be used.
 
 ## Modbus client
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ Some of rmodbus functions use vectors to store result.  Different vector types c
 - With the `fixedvec` feature, [`fixedvec::FixedVec`](https://crates.io/crates/fixedvec) can be used.
 - With the `heapless` feature, [`heapless::Vec`](https://crates.io/crates/fixedvec) can be used.
 
+- when the `std` feature is disable, and without `heapless` feature, and with `fixedvec` feature, no-std `alloc::vec::Vec` can be used.
+
 ## Modbus client
 
 Modbus client is designed with the same principles as the server: the crate

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -12,7 +12,13 @@ pub trait VectorTrait<T: Copy> {
     fn replace(&mut self, index: usize, value: T);
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(not(feature = "std"), not(feature = "heapless"), not(feature = "fixedvec")))]
+extern crate alloc;
+#[cfg(all(not(feature = "std"), not(feature = "heapless"), not(feature = "fixedvec")))]
+use alloc::vec::Vec;
+
+#[cfg(all(not(feature = "heapless"), not(feature = "fixedvec")))]
+//#[cfg(feature = "std")]
 impl<T: Copy> VectorTrait<T> for Vec<T> {
     #[inline]
     fn push(&mut self, value: T) -> Result<(), ErrorKind> {
@@ -139,3 +145,5 @@ impl<T: Copy, const N: usize> VectorTrait<T> for HeaplessVec<T, N> {
         self[index] = value;
     }
 }
+
+

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -12,13 +12,14 @@ pub trait VectorTrait<T: Copy> {
     fn replace(&mut self, index: usize, value: T);
 }
 
-#[cfg(all(not(feature = "std"), not(feature = "heapless"), not(feature = "fixedvec")))]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 extern crate alloc;
-#[cfg(all(not(feature = "std"), not(feature = "heapless"), not(feature = "fixedvec")))]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::vec::Vec;
+#[cfg(all(feature = "std", not(feature = "alloc")))]
+use std::vec::Vec;
 
-#[cfg(all(not(feature = "heapless"), not(feature = "fixedvec")))]
-//#[cfg(feature = "std")]
+#[cfg(any(feature = "alloc", feature = "std"))]
 impl<T: Copy> VectorTrait<T> for Vec<T> {
     #[inline]
     fn push(&mut self, value: T) -> Result<(), ErrorKind> {


### PR DESCRIPTION
when the `std` feature is disable, and without `heapless` feature, and without `fixedvec` feature, `alloc::vec::Vec in no-std ` can be used.