### PR TITLE
Make context abstract to allow users to insert their own context backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 TODO.todo
 target
 Cargo.lock
+.idea/

--- a/src/server/context.rs
+++ b/src/server/context.rs
@@ -6,25 +6,43 @@ use ieee754::Ieee754;
 use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
+/// A read-only context
+///
+/// Allows read access to all stored values.
 pub trait Context {
+    /// Get coils as Vec of u8
+    ///
+    /// Note: Vec is always appended
     fn get_coils_as_u8(
         &self,
         reg: u16,
         count: u16,
         buf: &mut impl VectorTrait<u8>,
     ) -> Result<(), ErrorKind>;
+
+    /// Get discretes as Vec of u8
+    ///
+    /// Note: Vec is always appended
     fn get_discretes_as_u8(
         &self,
         reg: u16,
         count: u16,
         buf: &mut impl VectorTrait<u8>,
     ) -> Result<(), ErrorKind>;
+
+    /// Get inputs as Vec of u8
+    ///
+    /// Note: Vec is always appended
     fn get_inputs_as_u8(
         &self,
         reg: u16,
         count: u16,
         buf: &mut impl VectorTrait<u8>,
     ) -> Result<(), ErrorKind>;
+
+    /// Get holdings as Vec of u8
+    ///
+    /// Note: Vec is always appended
     fn get_holdings_as_u8(
         &self,
         reg: u16,
@@ -114,10 +132,23 @@ where
     }
 }
 
+/// A writable context
+///
+/// This allows write access to a context. As it is a super trait to [Context] read access is also available.
 pub trait MutContext: Context {
+    /// Set a single coil
     fn set_coil(&mut self, reg: u16, val: bool) -> Result<(), ErrorKind>;
+
+    /// Set coils from Vec of u8
+    ///
+    /// As coils are packed in u8, parameter *count* specifies how many coils are actually needed
+    /// to set, extra bits are ignored
     fn set_coils_from_u8(&mut self, reg: u16, count: u16, buf: &[u8]) -> Result<(), ErrorKind>;
+
+    /// Set a single holding
     fn set_holding(&mut self, reg: u16, val: u16) -> Result<(), ErrorKind>;
+
+    /// Set holdings from Vec of u8
     fn set_holdings_from_u8(&mut self, reg: u16, buf: &[u8]) -> Result<(), ErrorKind>;
 }
 

--- a/src/server/context.rs
+++ b/src/server/context.rs
@@ -1,10 +1,10 @@
 use super::super::{ErrorKind, VectorTrait};
 #[cfg(feature = "with_bincode")]
 use bincode::{Decode, Encode};
+use core::ops::{Deref, DerefMut};
 use ieee754::Ieee754;
 #[cfg(feature = "with_serde")]
 use serde::{Deserialize, Serialize};
-use std::ops::{Deref, DerefMut};
 
 /// A read-only context
 ///

--- a/src/server/context.rs
+++ b/src/server/context.rs
@@ -4,6 +4,163 @@ use bincode::{Decode, Encode};
 use ieee754::Ieee754;
 #[cfg(feature = "with_serde")]
 use serde::{Deserialize, Serialize};
+use std::ops::{Deref, DerefMut};
+
+pub trait Context {
+    fn get_coils_as_u8(
+        &self,
+        reg: u16,
+        count: u16,
+        buf: &mut impl VectorTrait<u8>,
+    ) -> Result<(), ErrorKind>;
+    fn get_discretes_as_u8(
+        &self,
+        reg: u16,
+        count: u16,
+        buf: &mut impl VectorTrait<u8>,
+    ) -> Result<(), ErrorKind>;
+    fn get_inputs_as_u8(
+        &self,
+        reg: u16,
+        count: u16,
+        buf: &mut impl VectorTrait<u8>,
+    ) -> Result<(), ErrorKind>;
+    fn get_holdings_as_u8(
+        &self,
+        reg: u16,
+        count: u16,
+        buf: &mut impl VectorTrait<u8>,
+    ) -> Result<(), ErrorKind>;
+}
+
+impl<const C: usize, const D: usize, const I: usize, const H: usize> Context
+    for ModbusContext<C, D, I, H>
+{
+    fn get_coils_as_u8(
+        &self,
+        reg: u16,
+        count: u16,
+        buf: &mut impl VectorTrait<u8>,
+    ) -> Result<(), ErrorKind> {
+        self.get_coils_as_u8(reg, count, buf)
+    }
+
+    fn get_discretes_as_u8(
+        &self,
+        reg: u16,
+        count: u16,
+        buf: &mut impl VectorTrait<u8>,
+    ) -> Result<(), ErrorKind> {
+        self.get_discretes_as_u8(reg, count, buf)
+    }
+
+    fn get_inputs_as_u8(
+        &self,
+        reg: u16,
+        count: u16,
+        buf: &mut impl VectorTrait<u8>,
+    ) -> Result<(), ErrorKind> {
+        self.get_inputs_as_u8(reg, count, buf)
+    }
+
+    fn get_holdings_as_u8(
+        &self,
+        reg: u16,
+        count: u16,
+        buf: &mut impl VectorTrait<u8>,
+    ) -> Result<(), ErrorKind> {
+        self.get_holdings_as_u8(reg, count, buf)
+    }
+}
+
+impl<const C: usize, const D: usize, const I: usize, const H: usize, T> Context for T
+where
+    T: Deref<Target = ModbusContext<C, D, I, H>>,
+{
+    fn get_coils_as_u8(
+        &self,
+        reg: u16,
+        count: u16,
+        buf: &mut impl VectorTrait<u8>,
+    ) -> Result<(), ErrorKind> {
+        self.deref().get_coils_as_u8(reg, count, buf)
+    }
+
+    fn get_holdings_as_u8(
+        &self,
+        reg: u16,
+        count: u16,
+        buf: &mut impl VectorTrait<u8>,
+    ) -> Result<(), ErrorKind> {
+        self.deref().get_holdings_as_u8(reg, count, buf)
+    }
+
+    fn get_inputs_as_u8(
+        &self,
+        reg: u16,
+        count: u16,
+        buf: &mut impl VectorTrait<u8>,
+    ) -> Result<(), ErrorKind> {
+        self.deref().get_inputs_as_u8(reg, count, buf)
+    }
+
+    fn get_discretes_as_u8(
+        &self,
+        reg: u16,
+        count: u16,
+        buf: &mut impl VectorTrait<u8>,
+    ) -> Result<(), ErrorKind> {
+        self.deref().get_discretes_as_u8(reg, count, buf)
+    }
+}
+
+pub trait MutContext: Context {
+    fn set_coil(&mut self, reg: u16, val: bool) -> Result<(), ErrorKind>;
+    fn set_coils_from_u8(&mut self, reg: u16, count: u16, buf: &[u8]) -> Result<(), ErrorKind>;
+    fn set_holding(&mut self, reg: u16, val: u16) -> Result<(), ErrorKind>;
+    fn set_holdings_from_u8(&mut self, reg: u16, buf: &[u8]) -> Result<(), ErrorKind>;
+}
+
+impl<const C: usize, const D: usize, const I: usize, const H: usize> MutContext
+    for ModbusContext<C, D, I, H>
+{
+    fn set_coil(&mut self, reg: u16, val: bool) -> Result<(), ErrorKind> {
+        self.set_coil(reg, val)
+    }
+
+    fn set_coils_from_u8(&mut self, reg: u16, count: u16, buf: &[u8]) -> Result<(), ErrorKind> {
+        self.set_coils_from_u8(reg, count, buf)
+    }
+
+    fn set_holding(&mut self, reg: u16, val: u16) -> Result<(), ErrorKind> {
+        self.set_holding(reg, val)
+    }
+
+    fn set_holdings_from_u8(&mut self, reg: u16, buf: &[u8]) -> Result<(), ErrorKind> {
+        self.set_holdings_from_u8(reg, buf)
+    }
+}
+
+impl<const C: usize, const D: usize, const I: usize, const H: usize, T> MutContext for T
+where
+    T: DerefMut<Target = ModbusContext<C, D, I, H>>,
+{
+    fn set_coil(&mut self, reg: u16, val: bool) -> Result<(), ErrorKind> {
+        self.deref_mut().set_coil(reg, val)
+    }
+
+    fn set_coils_from_u8(&mut self, reg: u16, count: u16, buf: &[u8]) -> Result<(), ErrorKind> {
+        self.deref_mut().set_coils_from_u8(reg, count, buf)
+    }
+
+    fn set_holding(&mut self, reg: u16, val: u16) -> Result<(), ErrorKind> {
+        self.deref_mut().set_holding(reg, val)
+    }
+
+    fn set_holdings_from_u8(&mut self, reg: u16, buf: &[u8]) -> Result<(), ErrorKind> {
+        self.deref_mut().set_holdings_from_u8(reg, buf)
+    }
+}
 
 pub const SMALL_CONTEXT_SIZE: usize = 1_000;
 pub const FULL_CONTEXT_SIZE: usize = 10_000;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,4 +1,5 @@
 pub mod context;
+pub mod observer;
 
 use crate::consts::{
     MODBUS_ERROR_ILLEGAL_DATA_ADDRESS, MODBUS_ERROR_ILLEGAL_DATA_VALUE,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -7,6 +7,7 @@ use crate::consts::{
     MODBUS_SET_HOLDINGS_BULK,
 };
 use crate::{calc_crc16, calc_lrc, ErrorKind, ModbusFrameBuf, ModbusProto, VectorTrait};
+use context::{Context, MutContext};
 
 /// Modbus frame processor
 ///
@@ -146,10 +147,7 @@ impl<'a, V: VectorTrait<u8>> ModbusFrame<'a, V> {
         }
     }
     /// Process write functions
-    pub fn process_write<const C: usize, const D: usize, const I: usize, const H: usize>(
-        &mut self,
-        ctx: &mut context::ModbusContext<C, D, I, H>,
-    ) -> Result<(), ErrorKind> {
+    pub fn process_write<Ctx: MutContext>(&mut self, ctx: &mut Ctx) -> Result<(), ErrorKind> {
         match self.func {
             MODBUS_SET_COIL => {
                 // func 5
@@ -220,10 +218,7 @@ impl<'a, V: VectorTrait<u8>> ModbusFrame<'a, V> {
         }
     }
     /// Process read functions
-    pub fn process_read<const C: usize, const D: usize, const I: usize, const H: usize>(
-        &mut self,
-        ctx: &context::ModbusContext<C, D, I, H>,
-    ) -> Result<(), ErrorKind> {
+    pub fn process_read<Ctx: Context>(&mut self, ctx: &Ctx) -> Result<(), ErrorKind> {
         match self.func {
             MODBUS_GET_COILS | MODBUS_GET_DISCRETES => {
                 // funcs 1 - 2

--- a/src/server/observer.rs
+++ b/src/server/observer.rs
@@ -1,0 +1,123 @@
+use super::context::MutContext;
+use crate::server::context::Context;
+use crate::{ErrorKind, VectorTrait};
+
+struct ContextObserver<Ctx, FnPreWrite, FnPostWrite>
+where
+    Ctx: MutContext,
+    FnPreWrite: FnMut(WriteEvent, &Ctx),
+    FnPostWrite: FnMut(WriteEvent, &Ctx),
+{
+    pub ctx: Ctx,
+    pub pre_write: Option<FnPreWrite>,
+    pub post_write: Option<FnPostWrite>,
+}
+
+impl<Ctx, FnPreWrite, FnPostWrite> ContextObserver<Ctx, FnPreWrite, FnPostWrite>
+where
+    Ctx: MutContext,
+    FnPreWrite: FnMut(WriteEvent, &Ctx),
+    FnPostWrite: FnMut(WriteEvent, &Ctx),
+{
+    fn call<F>(&mut self, event: WriteEvent, f: F) -> Result<(), ErrorKind>
+    where
+        F: FnOnce(&mut Ctx) -> Result<(), ErrorKind>,
+    {
+        self.pre(event);
+        let res = f(&mut self.ctx);
+        self.post(event);
+
+        res
+    }
+
+    fn pre(&mut self, event: WriteEvent) {
+        if let Some(pre) = &mut self.pre_write {
+            pre(event, &self.ctx)
+        }
+    }
+
+    fn post(&mut self, event: WriteEvent) {
+        if let Some(post) = &mut self.post_write {
+            post(event, &self.ctx)
+        }
+    }
+}
+
+impl<Ctx, FnPreWrite, FnPostWrite> Context for ContextObserver<Ctx, FnPreWrite, FnPostWrite>
+where
+    Ctx: MutContext,
+    FnPreWrite: FnMut(WriteEvent, &Ctx),
+    FnPostWrite: FnMut(WriteEvent, &Ctx),
+{
+    fn get_coils_as_u8(
+        &self,
+        reg: u16,
+        count: u16,
+        buf: &mut impl VectorTrait<u8>,
+    ) -> Result<(), ErrorKind> {
+        self.ctx.get_coils_as_u8(reg, count, buf)
+    }
+
+    fn get_discretes_as_u8(
+        &self,
+        reg: u16,
+        count: u16,
+        buf: &mut impl VectorTrait<u8>,
+    ) -> Result<(), ErrorKind> {
+        self.ctx.get_discretes_as_u8(reg, count, buf)
+    }
+
+    fn get_inputs_as_u8(
+        &self,
+        reg: u16,
+        count: u16,
+        buf: &mut impl VectorTrait<u8>,
+    ) -> Result<(), ErrorKind> {
+        self.ctx.get_inputs_as_u8(reg, count, buf)
+    }
+
+    fn get_holdings_as_u8(
+        &self,
+        reg: u16,
+        count: u16,
+        buf: &mut impl VectorTrait<u8>,
+    ) -> Result<(), ErrorKind> {
+        self.ctx.get_holdings_as_u8(reg, count, buf)
+    }
+}
+
+impl<Ctx, FnPreWrite, FnPostWrite> MutContext for ContextObserver<Ctx, FnPreWrite, FnPostWrite>
+where
+    Ctx: MutContext,
+    FnPreWrite: FnMut(WriteEvent, &Ctx),
+    FnPostWrite: FnMut(WriteEvent, &Ctx),
+{
+    fn set_coil(&mut self, reg: u16, val: bool) -> Result<(), ErrorKind> {
+        let event = WriteEvent::Coils { reg, count: 1 };
+        self.call(event, |ctx| ctx.set_coil(reg, val))
+    }
+
+    fn set_coils_from_u8(&mut self, reg: u16, count: u16, buf: &[u8]) -> Result<(), ErrorKind> {
+        let event = WriteEvent::Coils { reg, count };
+        self.call(event, |ctx| ctx.set_coils_from_u8(reg, count, buf))
+    }
+
+    fn set_holding(&mut self, reg: u16, val: u16) -> Result<(), ErrorKind> {
+        let event = WriteEvent::Holdings { reg, count: 1 };
+        self.call(event, |ctx| ctx.set_holding(reg, val))
+    }
+
+    fn set_holdings_from_u8(&mut self, reg: u16, buf: &[u8]) -> Result<(), ErrorKind> {
+        let event = WriteEvent::Holdings {
+            reg,
+            count: buf.len() as u16 / 2,
+        };
+        self.call(event, |ctx| ctx.set_holdings_from_u8(reg, buf))
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum WriteEvent {
+    Coils { reg: u16, count: u16 },
+    Holdings { reg: u16, count: u16 },
+}

--- a/src/server/observer.rs
+++ b/src/server/observer.rs
@@ -84,6 +84,14 @@ where
     ) -> Result<(), ErrorKind> {
         self.ctx.get_holdings_as_u8(reg, count, buf)
     }
+
+    fn coil_len(&self) -> u16 {
+        self.ctx.coil_len()
+    }
+
+    fn holdings_len(&self) -> u16 {
+        self.ctx.holdings_len()
+    }
 }
 
 impl<Ctx, FnPreWrite, FnPostWrite> MutContext for ContextObserver<Ctx, FnPreWrite, FnPostWrite>


### PR DESCRIPTION
This moves all the functions needed for frame handling into two traits. The traits are then implemented for the current `ModbusContext` so that it can still be used as before. Annoyingly I also needed to explicitly add an implementation for anything that `Deref`s into a `ModbusContext`, but this allows all the tests and examples to just work as before (otherwise the compiler complained that the lock guard does not implement the trait). With the current methods this still has the downside that the user needs to do the parsing and serialization from/to `u8`s.

I also added a proof-of-concept for an observer that you can register callbacks with to be called when writes occur.

I think it still will need some work, but I would be happy about any feedback you have :)