### PR TITLE
bump heapless 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/lib.rs"
 [dependencies]
 ieee754 = "0.2.6"
 fixedvec = { version = "0.2.4", optional = true }
-heapless = { version = "0.7.13", optional = true }
+heapless = { version = "0.8.0", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_arrays = { version = "0.1.0", optional = true }
 bincode = { version = "2.0.0-rc.2", optional = true }


### PR DESCRIPTION
As the title, didn't notice any issue with it. Works fine and helps avoid having two version of heapless pulled in.