### PR TITLE
add defmt feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,19 @@ features = []
 features = []
 
 [lib]
-name ="rmodbus"
+name = "rmodbus"
 path = "src/lib.rs"
 
 [dependencies]
 ieee754 = "0.2.6"
 fixedvec = { version = "0.2.4", optional = true }
 heapless = { version = "0.7.13", optional = true }
-serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
+serde = { version = "1.0", default-features = false, features = [
+    "derive",
+], optional = true }
 serde_arrays = { version = "0.1.0", optional = true }
 bincode = { version = "2.0.0-rc.2", optional = true }
+defmt = { version = "0.3.0", optional = true }
 
 [features]
 default = ["std"]
@@ -37,12 +40,15 @@ with_bincode = ["bincode"]
 # including String, Box<T>, Vec<T>, and Cow<T>. This is a subset of std but may
 # be enabled without depending on all of std.
 alloc = []
+defmt = ["dep:defmt"]
 
 [dev-dependencies]
 rand = "0.7.3"
 crc16 = "0.4.0"
 serial = "0.4.0"
-lazy_static = { version = "1.4.0", features=["spin_no_std"], default-features = false }
+lazy_static = { version = "1.4.0", features = [
+    "spin_no_std",
+], default-features = false }
 fixedvec = "0.2.4"
 spin = "0.5.2"
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,6 +7,7 @@ use crate::{calc_crc16, calc_lrc, ErrorKind, ModbusFrameBuf, ModbusProto, Vector
 /// Modbus client generator/processor
 ///
 /// One object can be used for multiple calls
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ModbusRequest {
     /// transaction id, (TCP/UDP only), default: 1. To change, set the value manually
     pub tr_id: u16,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ErrorKind {
     OOB,
     OOBContext,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ mod tests;
 /// * for **TcpUdp**, Modbus TCP headers are parsed / added to replies
 /// * for **Rtu**, frame checksums are verified / added to replies
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ModbusProto {
     Rtu,
     Ascii,

--- a/src/server/context.rs
+++ b/src/server/context.rs
@@ -19,6 +19,7 @@ pub type ModbusContextFull =
 #[allow(clippy::module_name_repetitions)]
 #[cfg_attr(feature = "with_serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "with_bincode", derive(Decode, Encode))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ModbusContext<const C: usize, const D: usize, const I: usize, const H: usize> {
     #[cfg_attr(feature = "with_serde", serde(with = "serde_arrays"))]
     pub coils: [bool; C],

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -63,6 +63,7 @@ macro_rules! tcp_response_set_data_len {
     };
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ModbusFrame<'a, V: VectorTrait<u8>> {
     pub unit_id: u8,
     buf: &'a [u8],


### PR DESCRIPTION
Commonly used in embedded for logs.
Having it in rmodbus makes it easier to make rmodbus error inside own types with do have defmt::Format on them.
   