### PR TITLE
make ModbusContext a trait and move it sample impl to ModbusStorage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmodbus"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Serhij S. <div@altertech.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ use std::error::Error;
 use std::fs::File;
 use std::io::{Read, Write};
 
-use rmodbus::server::context::ModbusContextFull;
+use rmodbus::server::{storage::ModbusStorageFull, context::ModbusContext};
 
 #[path = "servers/tcp.rs"]
 mod srv;
@@ -219,19 +219,19 @@ For `no_std`, set the dependency as:
 rmodbus = { version = "*", default-features = false }
 ```
 
-## Small context
+## Small storage
 
-The full Modbus context has 10000 registers of each type, which requires 60000
+The full Modbus storage has 10000 registers of each type, which requires 60000
 bytes total. For systems with small RAM amount there is a pre-defined small
-context with 1000 registers:
+storage with 1000 registers:
 
 ```rust
-use rmodbus::server::context::ModbusContextSmall;
+use rmodbus::server::{storage::ModbusStorageSmall, context::ModbusContext};
 ```
 
-## Custom-sized context
+## Custom-sized storage
 
-Starting from the version 0.7 it is allowed to define context of any size using
+Starting from the version 0.7 it is allowed to define storage of any size using
 generic constants. The generic constants order is: coils, discretes, inputs,
 holdings.
 
@@ -239,11 +239,16 @@ E.g. let us define a context for 128 coils, 16 discretes, 0 inputs and 100
 holdings:
 
 ```rust
-use rmodbus::server::context::ModbusContext;
+use rmodbus::server::{storage::ModbusStorage, context::ModbusContext};
 
-let context = ModbusContext::<128, 16, 0, 100>::new();
+let context = ModbusStorage::<128, 16, 0, 100>::new();
 ```
 
+## Custom server implementation
+
+Starting from the version 0.9 it is allowed to provide custom server implementation 
+by implementing `use rmodbus::server::context::ModbusContext` on custom struct.
+For sample implementation have a look at `src/server/storage.rs`
 ## Vectors
 
 Some of rmodbus functions use vectors to store result.  Different vector types can be used:

--- a/examples/servers/ascii.rs
+++ b/examples/servers/ascii.rs
@@ -8,12 +8,12 @@ use std::sync::RwLock;
 
 use rmodbus::{
     generate_ascii_frame, guess_request_frame_len, parse_ascii_frame,
-    server::{context::ModbusContextFull, ModbusFrame},
+    server::{context::ModbusContext, storage::ModbusStorageFull, ModbusFrame},
     ModbusFrameBuf, ModbusProto,
 };
 
 lazy_static! {
-    pub static ref CONTEXT: RwLock<ModbusContextFull> = RwLock::new(ModbusContextFull::new());
+    pub static ref CONTEXT: RwLock<ModbusStorageFull> = RwLock::new(ModbusStorageFull::new());
 }
 
 pub fn asciiserver(unit: u8, port: &str) {
@@ -53,8 +53,8 @@ pub fn asciiserver(unit: u8, port: &str) {
             }
             if frame.processing_required {
                 let result = match frame.readonly {
-                    true => frame.process_read(&CONTEXT.read().unwrap()),
-                    false => frame.process_write(&mut CONTEXT.write().unwrap()),
+                    true => frame.process_read(&*CONTEXT.read().unwrap()),
+                    false => frame.process_write(&mut *CONTEXT.write().unwrap()),
                 };
                 if result.is_err() {
                     println!("frame processing error");

--- a/examples/servers/rtu.rs
+++ b/examples/servers/rtu.rs
@@ -7,12 +7,12 @@ use lazy_static::lazy_static;
 use std::sync::RwLock;
 
 use rmodbus::{
-    server::{context::ModbusContextFull, ModbusFrame},
+    server::{context::ModbusContext, storage::ModbusStorageFull, ModbusFrame},
     ModbusFrameBuf, ModbusProto,
 };
 
 lazy_static! {
-    pub static ref CONTEXT: RwLock<ModbusContextFull> = RwLock::new(ModbusContextFull::new());
+    pub static ref CONTEXT: RwLock<ModbusStorageFull> = RwLock::new(ModbusStorageFull::new());
 }
 
 pub fn rtuserver(unit: u8, port: &str) {
@@ -39,8 +39,8 @@ pub fn rtuserver(unit: u8, port: &str) {
             }
             if frame.processing_required {
                 let result = match frame.readonly {
-                    true => frame.process_read(&CONTEXT.read().unwrap()),
-                    false => frame.process_write(&mut CONTEXT.write().unwrap()),
+                    true => frame.process_read(&*CONTEXT.read().unwrap()),
+                    false => frame.process_write(&mut *CONTEXT.write().unwrap()),
                 };
                 if result.is_err() {
                     println!("frame processing error");

--- a/examples/servers/tcp.rs
+++ b/examples/servers/tcp.rs
@@ -7,12 +7,12 @@ use lazy_static::lazy_static;
 use std::sync::RwLock;
 
 use rmodbus::{
-    server::{context::ModbusContextFull, ModbusFrame},
+    server::{context::ModbusContext, storage::ModbusStorageFull, ModbusFrame},
     ModbusFrameBuf, ModbusProto,
 };
 
 lazy_static! {
-    pub static ref CONTEXT: RwLock<ModbusContextFull> = RwLock::new(ModbusContextFull::new());
+    pub static ref CONTEXT: RwLock<ModbusStorageFull> = RwLock::new(ModbusStorageFull::new());
 }
 
 pub fn tcpserver(unit: u8, listen: &str) {
@@ -35,8 +35,8 @@ pub fn tcpserver(unit: u8, listen: &str) {
                 }
                 if frame.processing_required {
                     let result = match frame.readonly {
-                        true => frame.process_read(&CONTEXT.read().unwrap()),
-                        false => frame.process_write(&mut CONTEXT.write().unwrap()),
+                        true => frame.process_read(&*CONTEXT.read().unwrap()),
+                        false => frame.process_write(&mut *CONTEXT.write().unwrap()),
                     };
                     if result.is_err() {
                         println!("frame processing error");

--- a/examples/servers/udp.rs
+++ b/examples/servers/udp.rs
@@ -5,12 +5,12 @@ use lazy_static::lazy_static;
 use std::sync::RwLock;
 
 use rmodbus::{
-    server::{context::ModbusContextFull, ModbusFrame},
+    server::{context::ModbusContext, storage::ModbusStorageFull, ModbusFrame},
     ModbusFrameBuf, ModbusProto,
 };
 
 lazy_static! {
-    pub static ref CONTEXT: RwLock<ModbusContextFull> = RwLock::new(ModbusContextFull::new());
+    pub static ref CONTEXT: RwLock<ModbusStorageFull> = RwLock::new(ModbusStorageFull::new());
 }
 
 pub fn udpserver(unit: u8, listen: &str) {
@@ -27,8 +27,8 @@ pub fn udpserver(unit: u8, listen: &str) {
         }
         if frame.processing_required {
             let result = match frame.readonly {
-                true => frame.process_read(&CONTEXT.read().unwrap()),
-                false => frame.process_write(&mut CONTEXT.write().unwrap()),
+                true => frame.process_read(&*CONTEXT.read().unwrap()),
+                false => frame.process_write(&mut *CONTEXT.write().unwrap()),
             };
             if result.is_err() {
                 println!("frame processing error");

--- a/src/server/context.rs
+++ b/src/server/context.rs
@@ -1,558 +1,194 @@
-use super::super::{ErrorKind, VectorTrait};
-#[cfg(feature = "with_bincode")]
-use bincode::{Decode, Encode};
-use ieee754::Ieee754;
-#[cfg(feature = "with_serde")]
-use serde::{Deserialize, Serialize};
+use crate::{ErrorKind, VectorTrait};
 
-pub const SMALL_CONTEXT_SIZE: usize = 1_000;
-pub const FULL_CONTEXT_SIZE: usize = 10_000;
-
-/// Small context (1000) registers per type
-pub type ModbusContextSmall =
-    ModbusContext<SMALL_CONTEXT_SIZE, SMALL_CONTEXT_SIZE, SMALL_CONTEXT_SIZE, SMALL_CONTEXT_SIZE>;
-/// Full context (10000) registers per type
-pub type ModbusContextFull =
-    ModbusContext<FULL_CONTEXT_SIZE, FULL_CONTEXT_SIZE, FULL_CONTEXT_SIZE, FULL_CONTEXT_SIZE>;
-
-/// Contains standard Modbus register contexts
-#[allow(clippy::module_name_repetitions)]
-#[cfg_attr(feature = "with_serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "with_bincode", derive(Decode, Encode))]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct ModbusContext<const C: usize, const D: usize, const I: usize, const H: usize> {
-    #[cfg_attr(feature = "with_serde", serde(with = "serde_arrays"))]
-    pub coils: [bool; C],
-    #[cfg_attr(feature = "with_serde", serde(with = "serde_arrays"))]
-    pub discretes: [bool; D],
-    #[cfg_attr(feature = "with_serde", serde(with = "serde_arrays"))]
-    pub inputs: [u16; I],
-    #[cfg_attr(feature = "with_serde", serde(with = "serde_arrays"))]
-    pub holdings: [u16; H],
-}
-
-macro_rules! get_regs_as_u8 {
-    ($reg_context:expr, $reg:expr, $count:expr, $result:expr, $ctx_size: expr) => {{
-        let reg_to = $reg as usize + $count as usize;
-        if reg_to > $ctx_size {
-            Err(ErrorKind::OOBContext)
-        } else {
-            for c in $reg as usize..reg_to {
-                $result.push(($reg_context[c] >> 8) as u8)?;
-                $result.push($reg_context[c] as u8)?;
-            }
-            Ok(())
-        }
-    }};
-}
-
-macro_rules! get_bools_as_u8 {
-    ($reg_context:expr, $reg:expr, $count:expr, $result:expr, $ctx_size: expr) => {{
-        let reg_to = $reg as usize + $count as usize;
-        if reg_to > $ctx_size {
-            Err(ErrorKind::OOBContext)
-        } else {
-            let mut creg = $reg as usize;
-            while creg < reg_to {
-                let mut cbyte = 0;
-                for i in 0..8 {
-                    if $reg_context[creg] {
-                        cbyte |= 1 << i
-                    }
-                    creg += 1;
-                    if creg >= reg_to {
-                        break;
-                    }
-                }
-                $result.push(cbyte)?;
-            }
-            Ok(())
-        }
-    }};
-}
-
-macro_rules! set_regs_from_u8 {
-    ($reg_context:expr, $reg:expr, $values:expr, $ctx_size: expr) => {{
-        let len = $values.len();
-        if $reg as usize + len / 2 > $ctx_size {
-            Err(ErrorKind::OOBContext)
-        } else {
-            let mut i = 0;
-            let mut creg = $reg as usize;
-            while i < len {
-                $reg_context[creg] = u16::from_be_bytes([
-                    $values[i],
-                    match i + 1 < len {
-                        true => $values[i + 1],
-                        false => return Err(ErrorKind::OOB),
-                    },
-                ]);
-                i += 2;
-                creg += 1;
-            }
-            Ok(())
-        }
-    }};
-}
-
-macro_rules! set_bools_from_u8 {
-    ($reg_context:expr, $reg:expr, $count:expr, $values:expr, $ctx_size: expr) => {{
-        let reg_to = $reg as usize + $count as usize;
-        if reg_to > $ctx_size {
-            Err(ErrorKind::OOBContext)
-        } else {
-            let mut creg = $reg as usize;
-            let mut cbyte = 0;
-            let mut cnt = 0;
-            let len = $values.len();
-            while creg < reg_to && cnt < $count {
-                if cbyte >= len {
-                    return Err(ErrorKind::OOB);
-                }
-                let mut b: u8 = $values[cbyte];
-                for _ in 0..8 {
-                    $reg_context[creg] = b & 1 == 1;
-                    b >>= 1;
-                    creg += 1;
-                    cnt += 1;
-                    if cnt == $count || creg == reg_to {
-                        break;
-                    }
-                }
-                cbyte += 1;
-            }
-            Ok(())
-        }
-    }};
-}
-
-macro_rules! get_bulk {
-    ($reg_context:expr, $reg:expr, $count:expr, $result:expr, $ctx_size: expr) => {{
-        let reg_to = $reg as usize + $count as usize;
-        if reg_to > $ctx_size {
-            Err(ErrorKind::OOBContext)
-        } else {
-            $result.extend(&$reg_context[$reg as usize..reg_to])?;
-            Ok(())
-        }
-    }};
-}
-
-macro_rules! set_bulk {
-    ($reg_context:expr, $reg:expr, $values:expr, $ctx_size: expr) => {
-        if $reg as usize + $values.len() > $ctx_size {
-            Err(ErrorKind::OOBContext)
-        } else {
-            for (i, value) in $values.iter().enumerate() {
-                $reg_context[$reg as usize + i] = *value;
-            }
-            Ok(())
-        }
-    };
-}
-
-macro_rules! get {
-    ($reg_context:expr, $reg:expr, $ctx_size: expr) => {
-        if $reg as usize >= $ctx_size {
-            Err(ErrorKind::OOBContext)
-        } else {
-            Ok($reg_context[$reg as usize])
-        }
-    };
-}
-
-macro_rules! set {
-    ($reg_context:expr, $reg:expr, $value:expr, $ctx_size: expr) => {
-        if $reg as usize >= $ctx_size {
-            Err(ErrorKind::OOBContext)
-        } else {
-            $reg_context[$reg as usize] = $value;
-            Ok(())
-        }
-    };
-}
-
-macro_rules! get_u32 {
-    ($reg_context:expr, $reg:expr, $ctx_size: expr) => {
-        if $reg as usize + 1 >= $ctx_size {
-            Err(ErrorKind::OOBContext)
-        } else {
-            Ok((($reg_context[$reg as usize] as u32) << 16)
-                + $reg_context[($reg as usize) + 1] as u32)
-        }
-    };
-}
-
-macro_rules! set_u32 {
-    ($reg_context:expr, $reg:expr, $value:expr, $ctx_size: expr) => {
-        if $reg as usize + 1 >= $ctx_size {
-            Err(ErrorKind::OOBContext)
-        } else {
-            $reg_context[$reg as usize] = ($value >> 16) as u16;
-            $reg_context[$reg as usize + 1] = $value as u16;
-            Ok(())
-        }
-    };
-}
-
-macro_rules! get_u64 {
-    ($reg_context:expr, $reg:expr, $ctx_size: expr) => {
-        if $reg as usize + 3 >= $ctx_size {
-            Err(ErrorKind::OOBContext)
-        } else {
-            Ok((($reg_context[$reg as usize] as u64) << 48)
-                + (($reg_context[$reg as usize + 1] as u64) << 32)
-                + (($reg_context[$reg as usize + 2] as u64) << 16)
-                + $reg_context[($reg as usize) + 3] as u64)
-        }
-    };
-}
-
-macro_rules! set_u64 {
-    ($reg_context:expr, $reg:expr, $value:expr, $ctx_size: expr) => {
-        if $reg as usize + 3 >= $ctx_size {
-            Err(ErrorKind::OOBContext)
-        } else {
-            $reg_context[$reg as usize] = ($value >> 48) as u16;
-            $reg_context[$reg as usize + 1] = ($value >> 32) as u16;
-            $reg_context[$reg as usize + 2] = ($value >> 16) as u16;
-            $reg_context[$reg as usize + 3] = $value as u16;
-            Ok(())
-        }
-    };
-}
-
-impl<const C: usize, const D: usize, const I: usize, const H: usize> Default
-    for ModbusContext<C, D, I, H>
-{
-    #[inline]
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<const C: usize, const D: usize, const I: usize, const H: usize> ModbusContext<C, D, I, H> {
-    /// Define a custom-sized context
-    ///
-    /// The generic constants order is: coils, discretes, inputs, holdings
-    ///
-    /// E.g. let us define a context for 128 coils, 16 discretes, 0 inputs and 100 holdings:
-    ///
-    /// ```
-    /// use rmodbus::server::context::ModbusContext;
-    ///
-    /// let context = ModbusContext::<128, 16, 0, 100>::new();
-    /// ```
-    #[inline]
-    pub const fn new() -> Self {
-        Self {
-            coils: [false; C],
-            discretes: [false; D],
-            inputs: [0; I],
-            holdings: [0; H],
-        }
-    }
-
-    pub fn clear_all(&mut self) {
-        self.clear_coils();
-        self.clear_discretes();
-        self.clear_inputs();
-        self.clear_holdings();
-    }
-
-    pub fn clear_coils(&mut self) {
-        for i in 0..C {
-            self.coils[i] = false;
-        }
-    }
-
-    pub fn clear_discretes(&mut self) {
-        for i in 0..D {
-            self.discretes[i] = false;
-        }
-    }
-
-    pub fn clear_inputs(&mut self) {
-        for i in 0..I {
-            self.inputs[i] = 0;
-        }
-    }
-
-    pub fn clear_holdings(&mut self) {
-        for i in 0..H {
-            self.holdings[i] = 0;
-        }
-    }
-
+pub trait ModbusContext {
     /// Get inputs as Vec of u8
     ///
     /// Note: Vec is always appended
-    pub fn get_inputs_as_u8<V: VectorTrait<u8>>(
+    fn get_inputs_as_u8<V: VectorTrait<u8>>(
         &self,
         reg: u16,
         count: u16,
         result: &mut V,
-    ) -> Result<(), ErrorKind> {
-        get_regs_as_u8!(self.inputs, reg, count, result, I)
-    }
+    ) -> Result<(), ErrorKind>;
 
     /// Get holdings as Vec of u8
     ///
     /// Note: Vec is always appended
-    pub fn get_holdings_as_u8<V: VectorTrait<u8>>(
+    fn get_holdings_as_u8<V: VectorTrait<u8>>(
         &self,
         reg: u16,
         count: u16,
         result: &mut V,
-    ) -> Result<(), ErrorKind> {
-        get_regs_as_u8!(self.holdings, reg, count, result, H)
-    }
+    ) -> Result<(), ErrorKind>;
 
     /// Set inputs from Vec of u8
-    pub fn set_inputs_from_u8(&mut self, reg: u16, values: &[u8]) -> Result<(), ErrorKind> {
-        set_regs_from_u8!(self.inputs, reg, values, I)
-    }
+    fn set_inputs_from_u8(&mut self, reg: u16, values: &[u8]) -> Result<(), ErrorKind>;
 
     /// Set holdings from Vec of u8
-    pub fn set_holdings_from_u8(&mut self, reg: u16, values: &[u8]) -> Result<(), ErrorKind> {
-        set_regs_from_u8!(self.holdings, reg, values, H)
-    }
+    fn set_holdings_from_u8(&mut self, reg: u16, values: &[u8]) -> Result<(), ErrorKind>;
 
     /// Get coils as Vec of u8
     ///
     /// Note: Vec is always appended
-    pub fn get_coils_as_u8<V: VectorTrait<u8>>(
+    fn get_coils_as_u8<V: VectorTrait<u8>>(
         &self,
         reg: u16,
         count: u16,
         result: &mut V,
-    ) -> Result<(), ErrorKind> {
-        get_bools_as_u8!(self.coils, reg, count, result, C)
-    }
+    ) -> Result<(), ErrorKind>;
 
     /// Get discretes as Vec of u8
     ///
     /// Note: Vec is always appended
-    pub fn get_discretes_as_u8<V: VectorTrait<u8>>(
+    fn get_discretes_as_u8<V: VectorTrait<u8>>(
         &self,
         reg: u16,
         count: u16,
         result: &mut V,
-    ) -> Result<(), ErrorKind> {
-        get_bools_as_u8!(self.discretes, reg, count, result, D)
-    }
+    ) -> Result<(), ErrorKind>;
 
     /// Set coils from Vec of u8
     ///
     /// As coils are packed in u8, parameter *count* specifies how many coils are actually needed
     /// to set, extra bits are ignored
-    pub fn set_coils_from_u8(
-        &mut self,
-        reg: u16,
-        count: u16,
-        values: &[u8],
-    ) -> Result<(), ErrorKind> {
-        set_bools_from_u8!(self.coils, reg, count, values, C)
-    }
+    fn set_coils_from_u8(&mut self, reg: u16, count: u16, values: &[u8]) -> Result<(), ErrorKind>;
 
     /// Set discretes from Vec of u8
     ///
     /// As discretes are packed in u8, parameter *count* specifies how many coils are actually
     /// needed to set, extra bits are ignored
-    pub fn set_discretes_from_u8(
+    fn set_discretes_from_u8(
         &mut self,
         reg: u16,
         count: u16,
         values: &[u8],
-    ) -> Result<(), ErrorKind> {
-        set_bools_from_u8!(self.discretes, reg, count, values, D)
-    }
+    ) -> Result<(), ErrorKind>;
 
     /// Bulk get coils
     ///
     /// Note: Vec is always appended
-    pub fn get_coils_bulk<V: VectorTrait<bool>>(
+    fn get_coils_bulk<V: VectorTrait<bool>>(
         &self,
         reg: u16,
         count: u16,
         result: &mut V,
-    ) -> Result<(), ErrorKind> {
-        get_bulk!(self.coils, reg, count, result, C)
-    }
+    ) -> Result<(), ErrorKind>;
 
     /// Bulk get discretes
     ///
     /// Note: Vec is always appended
-    pub fn get_discretes_bulk<V: VectorTrait<bool>>(
+    fn get_discretes_bulk<V: VectorTrait<bool>>(
         &self,
         reg: u16,
         count: u16,
         result: &mut V,
-    ) -> Result<(), ErrorKind> {
-        get_bulk!(self.discretes, reg, count, result, D)
-    }
+    ) -> Result<(), ErrorKind>;
 
     /// Bulk get inputs
     ///
     /// Note: Vec is always appended
-    pub fn get_inputs_bulk<V: VectorTrait<u16>>(
+    fn get_inputs_bulk<V: VectorTrait<u16>>(
         &self,
         reg: u16,
         count: u16,
         result: &mut V,
-    ) -> Result<(), ErrorKind> {
-        get_bulk!(self.inputs, reg, count, result, I)
-    }
+    ) -> Result<(), ErrorKind>;
 
     /// Bulk get holdings
     ///
     /// Note: Vec is always appended
-    pub fn get_holdings_bulk<V: VectorTrait<u16>>(
+    fn get_holdings_bulk<V: VectorTrait<u16>>(
         &self,
         reg: u16,
         count: u16,
         result: &mut V,
-    ) -> Result<(), ErrorKind> {
-        get_bulk!(self.holdings, reg, count, result, H)
-    }
+    ) -> Result<(), ErrorKind>;
 
     /// Bulk set coils
-    pub fn set_coils_bulk(&mut self, reg: u16, values: &[bool]) -> Result<(), ErrorKind> {
-        set_bulk!(self.coils, reg, values, C)
-    }
+    fn set_coils_bulk(&mut self, reg: u16, values: &[bool]) -> Result<(), ErrorKind>;
 
     /// Bulk set discretes
-    pub fn set_discretes_bulk(&mut self, reg: u16, values: &[bool]) -> Result<(), ErrorKind> {
-        set_bulk!(self.discretes, reg, values, D)
-    }
+    fn set_discretes_bulk(&mut self, reg: u16, values: &[bool]) -> Result<(), ErrorKind>;
 
     /// Bulk set inputs
-    pub fn set_inputs_bulk(&mut self, reg: u16, values: &[u16]) -> Result<(), ErrorKind> {
-        set_bulk!(self.inputs, reg, values, I)
-    }
+    fn set_inputs_bulk(&mut self, reg: u16, values: &[u16]) -> Result<(), ErrorKind>;
 
     /// Bulk set holdings
-    pub fn set_holdings_bulk(&mut self, reg: u16, values: &[u16]) -> Result<(), ErrorKind> {
-        set_bulk!(self.holdings, reg, values, H)
-    }
+    fn set_holdings_bulk(&mut self, reg: u16, values: &[u16]) -> Result<(), ErrorKind>;
 
     /// Get a single coil
-    pub fn get_coil(&self, reg: u16) -> Result<bool, ErrorKind> {
-        get!(self.coils, reg, C)
-    }
+    fn get_coil(&self, reg: u16) -> Result<bool, ErrorKind>;
 
     /// Get a single discrete
-    pub fn get_discrete(&self, reg: u16) -> Result<bool, ErrorKind> {
-        get!(self.discretes, reg, D)
-    }
+    fn get_discrete(&self, reg: u16) -> Result<bool, ErrorKind>;
 
     /// Get a single input
-    pub fn get_input(&self, reg: u16) -> Result<u16, ErrorKind> {
-        get!(self.inputs, reg, I)
-    }
+    fn get_input(&self, reg: u16) -> Result<u16, ErrorKind>;
 
     /// Get a single holding
-    pub fn get_holding(&self, reg: u16) -> Result<u16, ErrorKind> {
-        get!(self.holdings, reg, H)
-    }
+    fn get_holding(&self, reg: u16) -> Result<u16, ErrorKind>;
 
     /// Set a single coil
-    pub fn set_coil(&mut self, reg: u16, value: bool) -> Result<(), ErrorKind> {
-        set!(self.coils, reg, value, C)
-    }
+    fn set_coil(&mut self, reg: u16, value: bool) -> Result<(), ErrorKind>;
 
     /// Set a single discrete
-    pub fn set_discrete(&mut self, reg: u16, value: bool) -> Result<(), ErrorKind> {
-        set!(self.discretes, reg, value, D)
-    }
+    fn set_discrete(&mut self, reg: u16, value: bool) -> Result<(), ErrorKind>;
 
     /// Set a single input
-    pub fn set_input(&mut self, reg: u16, value: u16) -> Result<(), ErrorKind> {
-        set!(self.inputs, reg, value, I)
-    }
+    fn set_input(&mut self, reg: u16, value: u16) -> Result<(), ErrorKind>;
 
     /// Set a single holding
-    pub fn set_holding(&mut self, reg: u16, value: u16) -> Result<(), ErrorKind> {
-        set!(self.holdings, reg, value, H)
-    }
+    fn set_holding(&mut self, reg: u16, value: u16) -> Result<(), ErrorKind>;
 
     /// Get two inputs as u32
     ///
     /// Returns 32-bit value (big-endian)
-    pub fn get_inputs_as_u32(&self, reg: u16) -> Result<u32, ErrorKind> {
-        get_u32!(self.inputs, reg, I)
-    }
+    fn get_inputs_as_u32(&self, reg: u16) -> Result<u32, ErrorKind>;
 
     /// Get two holdings as u32
     ///
     /// Returns 32-bit value (big-endian)
-    pub fn get_holdings_as_u32(&self, reg: u16) -> Result<u32, ErrorKind> {
-        get_u32!(self.holdings, reg, H)
-    }
+    fn get_holdings_as_u32(&self, reg: u16) -> Result<u32, ErrorKind>;
 
     /// Set two inputs from u32
     ///
     /// Uses 32-bit value to set two registers (big-endian)
-    pub fn set_inputs_from_u32(&mut self, reg: u16, value: u32) -> Result<(), ErrorKind> {
-        set_u32!(self.inputs, reg, value, I)
-    }
+    fn set_inputs_from_u32(&mut self, reg: u16, value: u32) -> Result<(), ErrorKind>;
 
     /// Set two holdings from u32
     ///
     /// Uses 32-bit value to set two registers (big-endian)
-    pub fn set_holdings_from_u32(&mut self, reg: u16, value: u32) -> Result<(), ErrorKind> {
-        set_u32!(self.holdings, reg, value, H)
-    }
+    fn set_holdings_from_u32(&mut self, reg: u16, value: u32) -> Result<(), ErrorKind>;
 
     /// Get four inputs as u64
     ///
     /// Returns 64-bit value (big-endian)
-    pub fn get_inputs_as_u64(&self, reg: u16) -> Result<u64, ErrorKind> {
-        get_u64!(self.inputs, reg, I)
-    }
+    fn get_inputs_as_u64(&self, reg: u16) -> Result<u64, ErrorKind>;
 
     /// Get four holdings as u64
     ///
     /// Returns 64-bit value (big-endian)
-    pub fn get_holdings_as_u64(&self, reg: u16) -> Result<u64, ErrorKind> {
-        get_u64!(self.holdings, reg, H)
-    }
+    fn get_holdings_as_u64(&self, reg: u16) -> Result<u64, ErrorKind>;
 
     /// Set four inputs from u64
     ///
     /// Uses 64-bit value to set four registers (big-endian)
-    pub fn set_inputs_from_u64(&mut self, reg: u16, value: u64) -> Result<(), ErrorKind> {
-        set_u64!(self.inputs, reg, value, I)
-    }
+    fn set_inputs_from_u64(&mut self, reg: u16, value: u64) -> Result<(), ErrorKind>;
 
     /// Set four holdings from u64
     ///
     /// Uses 64-bit value to set four registers (big-endian)
-    pub fn set_holdings_from_u64(&mut self, reg: u16, value: u64) -> Result<(), ErrorKind> {
-        set_u64!(self.holdings, reg, value, H)
-    }
+    fn set_holdings_from_u64(&mut self, reg: u16, value: u64) -> Result<(), ErrorKind>;
 
     /// Get two input registers as IEEE754 32-bit float
-    #[inline]
-    pub fn get_inputs_as_f32(&self, reg: u16) -> Result<f32, ErrorKind> {
-        Ok(Ieee754::from_bits(self.get_inputs_as_u32(reg)?))
-    }
+    fn get_inputs_as_f32(&self, reg: u16) -> Result<f32, ErrorKind>;
 
     /// Get two holding registers as IEEE754 32-bit float
-    #[inline]
-    pub fn get_holdings_as_f32(&self, reg: u16) -> Result<f32, ErrorKind> {
-        Ok(Ieee754::from_bits(self.get_holdings_as_u32(reg)?))
-    }
+    fn get_holdings_as_f32(&self, reg: u16) -> Result<f32, ErrorKind>;
 
     /// Set IEEE 754 f32 to two input registers
-    #[inline]
-    pub fn set_inputs_from_f32(&mut self, reg: u16, value: f32) -> Result<(), ErrorKind> {
-        self.set_inputs_from_u32(reg, value.bits())
-    }
+    fn set_inputs_from_f32(&mut self, reg: u16, value: f32) -> Result<(), ErrorKind>;
 
     /// Set IEEE 754 f32 to two holding registers
-    #[inline]
-    pub fn set_holdings_from_f32(&mut self, reg: u16, value: f32) -> Result<(), ErrorKind> {
-        self.set_holdings_from_u32(reg, value.bits())
-    }
+    fn set_holdings_from_f32(&mut self, reg: u16, value: f32) -> Result<(), ErrorKind>;
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -14,11 +14,11 @@ use crate::{calc_crc16, calc_lrc, ErrorKind, ModbusProto, VectorTrait};
 /// ```no_run
 /// # #[cfg(feature = "fixedvec")]
 /// # mod with_fixedvec {
-/// use rmodbus::{ModbusFrameBuf, ModbusProto, server::{ModbusFrame, context::ModbusContextFull}};
+/// use rmodbus::{ModbusFrameBuf, ModbusProto, server::{ModbusFrame, storage::ModbusStorageFull, context::ModbusContext}};
 /// use fixedvec::{FixedVec, alloc_stack}; // for std use regular std::vec::Vec
 ///
 /// # fn code() {
-/// let mut ctx = ModbusContextFull::new();
+/// let mut ctx = ModbusStorageFull::new();
 ///
 /// let unit_id = 1;
 /// loop {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,4 +1,5 @@
 pub mod context;
+pub mod storage;
 
 use crate::consts::{
     MODBUS_ERROR_ILLEGAL_DATA_ADDRESS, MODBUS_ERROR_ILLEGAL_DATA_VALUE,
@@ -142,9 +143,9 @@ impl<'a, V: VectorTrait<u8>> ModbusFrame<'a, V> {
         }
     }
     /// Process write functions
-    pub fn process_write<const C: usize, const D: usize, const I: usize, const H: usize>(
+    pub fn process_write<C: context::ModbusContext>(
         &mut self,
-        ctx: &mut context::ModbusContext<C, D, I, H>,
+        ctx: &mut C,
     ) -> Result<(), ErrorKind> {
         match self.func {
             MODBUS_SET_COIL => {
@@ -216,10 +217,7 @@ impl<'a, V: VectorTrait<u8>> ModbusFrame<'a, V> {
         }
     }
     /// Process read functions
-    pub fn process_read<const C: usize, const D: usize, const I: usize, const H: usize>(
-        &mut self,
-        ctx: &context::ModbusContext<C, D, I, H>,
-    ) -> Result<(), ErrorKind> {
+    pub fn process_read<C: context::ModbusContext>(&mut self, ctx: &C) -> Result<(), ErrorKind> {
         match self.func {
             MODBUS_GET_COILS | MODBUS_GET_DISCRETES => {
                 // funcs 1 - 2

--- a/src/server/storage.rs
+++ b/src/server/storage.rs
@@ -1,0 +1,484 @@
+use super::{
+    super::{ErrorKind, VectorTrait},
+    context::ModbusContext,
+};
+#[cfg(feature = "with_bincode")]
+use bincode::{Decode, Encode};
+use ieee754::Ieee754;
+#[cfg(feature = "with_serde")]
+use serde::{Deserialize, Serialize};
+
+pub const SMALL_STORAGE_SIZE: usize = 1_000;
+pub const FULL_STORAGE_SIZE: usize = 10_000;
+
+/// Small context (1000) registers per type
+pub type ModbusStorageSmall =
+    ModbusStorage<SMALL_STORAGE_SIZE, SMALL_STORAGE_SIZE, SMALL_STORAGE_SIZE, SMALL_STORAGE_SIZE>;
+/// Full context (10000) registers per type
+pub type ModbusStorageFull =
+    ModbusStorage<FULL_STORAGE_SIZE, FULL_STORAGE_SIZE, FULL_STORAGE_SIZE, FULL_STORAGE_SIZE>;
+
+/// Contains standard Modbus register contexts
+#[allow(clippy::module_name_repetitions)]
+#[cfg_attr(feature = "with_serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "with_bincode", derive(Decode, Encode))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct ModbusStorage<const C: usize, const D: usize, const I: usize, const H: usize> {
+    #[cfg_attr(feature = "with_serde", serde(with = "serde_arrays"))]
+    pub coils: [bool; C],
+    #[cfg_attr(feature = "with_serde", serde(with = "serde_arrays"))]
+    pub discretes: [bool; D],
+    #[cfg_attr(feature = "with_serde", serde(with = "serde_arrays"))]
+    pub inputs: [u16; I],
+    #[cfg_attr(feature = "with_serde", serde(with = "serde_arrays"))]
+    pub holdings: [u16; H],
+}
+
+macro_rules! get_regs_as_u8 {
+    ($reg_context:expr, $reg:expr, $count:expr, $result:expr, $ctx_size: expr) => {{
+        let reg_to = $reg as usize + $count as usize;
+        if reg_to > $ctx_size {
+            Err(ErrorKind::OOBContext)
+        } else {
+            for c in $reg as usize..reg_to {
+                $result.push(($reg_context[c] >> 8) as u8)?;
+                $result.push($reg_context[c] as u8)?;
+            }
+            Ok(())
+        }
+    }};
+}
+
+macro_rules! get_bools_as_u8 {
+    ($reg_context:expr, $reg:expr, $count:expr, $result:expr, $ctx_size: expr) => {{
+        let reg_to = $reg as usize + $count as usize;
+        if reg_to > $ctx_size {
+            Err(ErrorKind::OOBContext)
+        } else {
+            let mut creg = $reg as usize;
+            while creg < reg_to {
+                let mut cbyte = 0;
+                for i in 0..8 {
+                    if $reg_context[creg] {
+                        cbyte |= 1 << i
+                    }
+                    creg += 1;
+                    if creg >= reg_to {
+                        break;
+                    }
+                }
+                $result.push(cbyte)?;
+            }
+            Ok(())
+        }
+    }};
+}
+
+macro_rules! set_regs_from_u8 {
+    ($reg_context:expr, $reg:expr, $values:expr, $ctx_size: expr) => {{
+        let len = $values.len();
+        if $reg as usize + len / 2 > $ctx_size {
+            Err(ErrorKind::OOBContext)
+        } else {
+            let mut i = 0;
+            let mut creg = $reg as usize;
+            while i < len {
+                $reg_context[creg] = u16::from_be_bytes([
+                    $values[i],
+                    match i + 1 < len {
+                        true => $values[i + 1],
+                        false => return Err(ErrorKind::OOB),
+                    },
+                ]);
+                i += 2;
+                creg += 1;
+            }
+            Ok(())
+        }
+    }};
+}
+
+macro_rules! set_bools_from_u8 {
+    ($reg_context:expr, $reg:expr, $count:expr, $values:expr, $ctx_size: expr) => {{
+        let reg_to = $reg as usize + $count as usize;
+        if reg_to > $ctx_size {
+            Err(ErrorKind::OOBContext)
+        } else {
+            let mut creg = $reg as usize;
+            let mut cbyte = 0;
+            let mut cnt = 0;
+            let len = $values.len();
+            while creg < reg_to && cnt < $count {
+                if cbyte >= len {
+                    return Err(ErrorKind::OOB);
+                }
+                let mut b: u8 = $values[cbyte];
+                for _ in 0..8 {
+                    $reg_context[creg] = b & 1 == 1;
+                    b >>= 1;
+                    creg += 1;
+                    cnt += 1;
+                    if cnt == $count || creg == reg_to {
+                        break;
+                    }
+                }
+                cbyte += 1;
+            }
+            Ok(())
+        }
+    }};
+}
+
+macro_rules! get_bulk {
+    ($reg_context:expr, $reg:expr, $count:expr, $result:expr, $ctx_size: expr) => {{
+        let reg_to = $reg as usize + $count as usize;
+        if reg_to > $ctx_size {
+            Err(ErrorKind::OOBContext)
+        } else {
+            $result.extend(&$reg_context[$reg as usize..reg_to])?;
+            Ok(())
+        }
+    }};
+}
+
+macro_rules! set_bulk {
+    ($reg_context:expr, $reg:expr, $values:expr, $ctx_size: expr) => {
+        if $reg as usize + $values.len() > $ctx_size {
+            Err(ErrorKind::OOBContext)
+        } else {
+            for (i, value) in $values.iter().enumerate() {
+                $reg_context[$reg as usize + i] = *value;
+            }
+            Ok(())
+        }
+    };
+}
+
+macro_rules! get {
+    ($reg_context:expr, $reg:expr, $ctx_size: expr) => {
+        if $reg as usize >= $ctx_size {
+            Err(ErrorKind::OOBContext)
+        } else {
+            Ok($reg_context[$reg as usize])
+        }
+    };
+}
+
+macro_rules! set {
+    ($reg_context:expr, $reg:expr, $value:expr, $ctx_size: expr) => {
+        if $reg as usize >= $ctx_size {
+            Err(ErrorKind::OOBContext)
+        } else {
+            $reg_context[$reg as usize] = $value;
+            Ok(())
+        }
+    };
+}
+
+macro_rules! get_u32 {
+    ($reg_context:expr, $reg:expr, $ctx_size: expr) => {
+        if $reg as usize + 1 >= $ctx_size {
+            Err(ErrorKind::OOBContext)
+        } else {
+            Ok((($reg_context[$reg as usize] as u32) << 16)
+                + $reg_context[($reg as usize) + 1] as u32)
+        }
+    };
+}
+
+macro_rules! set_u32 {
+    ($reg_context:expr, $reg:expr, $value:expr, $ctx_size: expr) => {
+        if $reg as usize + 1 >= $ctx_size {
+            Err(ErrorKind::OOBContext)
+        } else {
+            $reg_context[$reg as usize] = ($value >> 16) as u16;
+            $reg_context[$reg as usize + 1] = $value as u16;
+            Ok(())
+        }
+    };
+}
+
+macro_rules! get_u64 {
+    ($reg_context:expr, $reg:expr, $ctx_size: expr) => {
+        if $reg as usize + 3 >= $ctx_size {
+            Err(ErrorKind::OOBContext)
+        } else {
+            Ok((($reg_context[$reg as usize] as u64) << 48)
+                + (($reg_context[$reg as usize + 1] as u64) << 32)
+                + (($reg_context[$reg as usize + 2] as u64) << 16)
+                + $reg_context[($reg as usize) + 3] as u64)
+        }
+    };
+}
+
+macro_rules! set_u64 {
+    ($reg_context:expr, $reg:expr, $value:expr, $ctx_size: expr) => {
+        if $reg as usize + 3 >= $ctx_size {
+            Err(ErrorKind::OOBContext)
+        } else {
+            $reg_context[$reg as usize] = ($value >> 48) as u16;
+            $reg_context[$reg as usize + 1] = ($value >> 32) as u16;
+            $reg_context[$reg as usize + 2] = ($value >> 16) as u16;
+            $reg_context[$reg as usize + 3] = $value as u16;
+            Ok(())
+        }
+    };
+}
+
+impl<const C: usize, const D: usize, const I: usize, const H: usize> Default
+    for ModbusStorage<C, D, I, H>
+{
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const C: usize, const D: usize, const I: usize, const H: usize> ModbusStorage<C, D, I, H> {
+    /// Define a custom-sized context
+    ///
+    /// The generic constants order is: coils, discretes, inputs, holdings
+    ///
+    /// E.g. let us define a context for 128 coils, 16 discretes, 0 inputs and 100 holdings:
+    ///
+    /// ```
+    /// use rmodbus::server::storage::ModbusStorage;
+    ///
+    /// let context = ModbusStorage::<128, 16, 0, 100>::new();
+    /// ```
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            coils: [false; C],
+            discretes: [false; D],
+            inputs: [0; I],
+            holdings: [0; H],
+        }
+    }
+
+    pub fn clear_all(&mut self) {
+        self.clear_coils();
+        self.clear_discretes();
+        self.clear_inputs();
+        self.clear_holdings();
+    }
+
+    pub fn clear_coils(&mut self) {
+        for i in 0..C {
+            self.coils[i] = false;
+        }
+    }
+
+    pub fn clear_discretes(&mut self) {
+        for i in 0..D {
+            self.discretes[i] = false;
+        }
+    }
+
+    pub fn clear_inputs(&mut self) {
+        for i in 0..I {
+            self.inputs[i] = 0;
+        }
+    }
+
+    pub fn clear_holdings(&mut self) {
+        for i in 0..H {
+            self.holdings[i] = 0;
+        }
+    }
+}
+
+impl<const C: usize, const D: usize, const I: usize, const H: usize> ModbusContext
+    for ModbusStorage<C, D, I, H>
+{
+    fn get_inputs_as_u8<V: VectorTrait<u8>>(
+        &self,
+        reg: u16,
+        count: u16,
+        result: &mut V,
+    ) -> Result<(), ErrorKind> {
+        get_regs_as_u8!(self.inputs, reg, count, result, I)
+    }
+
+    fn get_holdings_as_u8<V: VectorTrait<u8>>(
+        &self,
+        reg: u16,
+        count: u16,
+        result: &mut V,
+    ) -> Result<(), ErrorKind> {
+        get_regs_as_u8!(self.holdings, reg, count, result, H)
+    }
+
+    fn set_inputs_from_u8(&mut self, reg: u16, values: &[u8]) -> Result<(), ErrorKind> {
+        set_regs_from_u8!(self.inputs, reg, values, I)
+    }
+
+    fn set_holdings_from_u8(&mut self, reg: u16, values: &[u8]) -> Result<(), ErrorKind> {
+        set_regs_from_u8!(self.holdings, reg, values, H)
+    }
+
+    fn get_coils_as_u8<V: VectorTrait<u8>>(
+        &self,
+        reg: u16,
+        count: u16,
+        result: &mut V,
+    ) -> Result<(), ErrorKind> {
+        get_bools_as_u8!(self.coils, reg, count, result, C)
+    }
+
+    fn get_discretes_as_u8<V: VectorTrait<u8>>(
+        &self,
+        reg: u16,
+        count: u16,
+        result: &mut V,
+    ) -> Result<(), ErrorKind> {
+        get_bools_as_u8!(self.discretes, reg, count, result, D)
+    }
+
+    fn set_coils_from_u8(&mut self, reg: u16, count: u16, values: &[u8]) -> Result<(), ErrorKind> {
+        set_bools_from_u8!(self.coils, reg, count, values, C)
+    }
+
+    fn set_discretes_from_u8(
+        &mut self,
+        reg: u16,
+        count: u16,
+        values: &[u8],
+    ) -> Result<(), ErrorKind> {
+        set_bools_from_u8!(self.discretes, reg, count, values, D)
+    }
+
+    fn get_coils_bulk<V: VectorTrait<bool>>(
+        &self,
+        reg: u16,
+        count: u16,
+        result: &mut V,
+    ) -> Result<(), ErrorKind> {
+        get_bulk!(self.coils, reg, count, result, C)
+    }
+
+    fn get_discretes_bulk<V: VectorTrait<bool>>(
+        &self,
+        reg: u16,
+        count: u16,
+        result: &mut V,
+    ) -> Result<(), ErrorKind> {
+        get_bulk!(self.discretes, reg, count, result, D)
+    }
+
+    fn get_inputs_bulk<V: VectorTrait<u16>>(
+        &self,
+        reg: u16,
+        count: u16,
+        result: &mut V,
+    ) -> Result<(), ErrorKind> {
+        get_bulk!(self.inputs, reg, count, result, I)
+    }
+
+    fn get_holdings_bulk<V: VectorTrait<u16>>(
+        &self,
+        reg: u16,
+        count: u16,
+        result: &mut V,
+    ) -> Result<(), ErrorKind> {
+        get_bulk!(self.holdings, reg, count, result, H)
+    }
+
+    fn set_coils_bulk(&mut self, reg: u16, values: &[bool]) -> Result<(), ErrorKind> {
+        set_bulk!(self.coils, reg, values, C)
+    }
+
+    fn set_discretes_bulk(&mut self, reg: u16, values: &[bool]) -> Result<(), ErrorKind> {
+        set_bulk!(self.discretes, reg, values, D)
+    }
+
+    fn set_inputs_bulk(&mut self, reg: u16, values: &[u16]) -> Result<(), ErrorKind> {
+        set_bulk!(self.inputs, reg, values, I)
+    }
+
+    fn set_holdings_bulk(&mut self, reg: u16, values: &[u16]) -> Result<(), ErrorKind> {
+        set_bulk!(self.holdings, reg, values, H)
+    }
+
+    fn get_coil(&self, reg: u16) -> Result<bool, ErrorKind> {
+        get!(self.coils, reg, C)
+    }
+
+    fn get_discrete(&self, reg: u16) -> Result<bool, ErrorKind> {
+        get!(self.discretes, reg, D)
+    }
+
+    fn get_input(&self, reg: u16) -> Result<u16, ErrorKind> {
+        get!(self.inputs, reg, I)
+    }
+
+    fn get_holding(&self, reg: u16) -> Result<u16, ErrorKind> {
+        get!(self.holdings, reg, H)
+    }
+
+    fn set_coil(&mut self, reg: u16, value: bool) -> Result<(), ErrorKind> {
+        set!(self.coils, reg, value, C)
+    }
+
+    fn set_discrete(&mut self, reg: u16, value: bool) -> Result<(), ErrorKind> {
+        set!(self.discretes, reg, value, D)
+    }
+
+    fn set_input(&mut self, reg: u16, value: u16) -> Result<(), ErrorKind> {
+        set!(self.inputs, reg, value, I)
+    }
+
+    fn set_holding(&mut self, reg: u16, value: u16) -> Result<(), ErrorKind> {
+        set!(self.holdings, reg, value, H)
+    }
+
+    fn get_inputs_as_u32(&self, reg: u16) -> Result<u32, ErrorKind> {
+        get_u32!(self.inputs, reg, I)
+    }
+
+    fn get_holdings_as_u32(&self, reg: u16) -> Result<u32, ErrorKind> {
+        get_u32!(self.holdings, reg, H)
+    }
+
+    fn set_inputs_from_u32(&mut self, reg: u16, value: u32) -> Result<(), ErrorKind> {
+        set_u32!(self.inputs, reg, value, I)
+    }
+
+    fn set_holdings_from_u32(&mut self, reg: u16, value: u32) -> Result<(), ErrorKind> {
+        set_u32!(self.holdings, reg, value, H)
+    }
+
+    fn get_inputs_as_u64(&self, reg: u16) -> Result<u64, ErrorKind> {
+        get_u64!(self.inputs, reg, I)
+    }
+
+    fn get_holdings_as_u64(&self, reg: u16) -> Result<u64, ErrorKind> {
+        get_u64!(self.holdings, reg, H)
+    }
+
+    fn set_inputs_from_u64(&mut self, reg: u16, value: u64) -> Result<(), ErrorKind> {
+        set_u64!(self.inputs, reg, value, I)
+    }
+
+    fn set_holdings_from_u64(&mut self, reg: u16, value: u64) -> Result<(), ErrorKind> {
+        set_u64!(self.holdings, reg, value, H)
+    }
+
+    fn get_inputs_as_f32(&self, reg: u16) -> Result<f32, ErrorKind> {
+        Ok(Ieee754::from_bits(self.get_inputs_as_u32(reg)?))
+    }
+
+    fn get_holdings_as_f32(&self, reg: u16) -> Result<f32, ErrorKind> {
+        Ok(Ieee754::from_bits(self.get_holdings_as_u32(reg)?))
+    }
+
+    #[inline]
+    fn set_inputs_from_f32(&mut self, reg: u16, value: f32) -> Result<(), ErrorKind> {
+        self.set_inputs_from_u32(reg, value.bits())
+    }
+
+    #[inline]
+    fn set_holdings_from_f32(&mut self, reg: u16, value: f32) -> Result<(), ErrorKind> {
+        self.set_holdings_from_u32(reg, value.bits())
+    }
+}

--- a/src/tests/test_std.rs
+++ b/src/tests/test_std.rs
@@ -1,39 +1,40 @@
 use crate::client::*;
-use crate::server::context::{ModbusContextFull, FULL_CONTEXT_SIZE as CONTEXT_SIZE};
+use crate::server::context::ModbusContext;
+use crate::server::storage::{ModbusStorageFull, FULL_STORAGE_SIZE as STORAGE_SIZE};
 use crate::server::*;
 use crate::*;
 use crc16::*;
 use std::sync::RwLock;
 
 lazy_static! {
-    pub static ref CTX: RwLock<ModbusContextFull> = RwLock::new(ModbusContextFull::new());
+    pub static ref CTX: RwLock<ModbusStorageFull> = RwLock::new(ModbusStorageFull::new());
 }
 
 #[test]
 fn test_std_read_coils_as_bytes_oob() {
     let mut ctx = CTX.write().unwrap();
     let mut result = Vec::new();
-    match ctx.get_coils_bulk(0, CONTEXT_SIZE as u16 + 1, &mut result) {
+    match ctx.get_coils_bulk(0, STORAGE_SIZE as u16 + 1, &mut result) {
         Ok(_) => assert!(false, "oob failed 0 - MAX+1 "),
         Err(_) => assert!(true),
     }
-    match ctx.get_coils_bulk(CONTEXT_SIZE as u16, 1, &mut result) {
+    match ctx.get_coils_bulk(STORAGE_SIZE as u16, 1, &mut result) {
         Ok(_) => assert!(false, "oob failed MAX - MAX+1"),
         Err(_) => assert!(true),
     }
-    ctx.get_coils_bulk((CONTEXT_SIZE - 1) as u16, 1, &mut result)
+    ctx.get_coils_bulk((STORAGE_SIZE - 1) as u16, 1, &mut result)
         .unwrap();
-    match ctx.get_coils_bulk(CONTEXT_SIZE as u16 - 1, 2, &mut result) {
+    match ctx.get_coils_bulk(STORAGE_SIZE as u16 - 1, 2, &mut result) {
         Ok(_) => assert!(false, "oob failed MAX - MAX+1"),
         Err(_) => assert!(true),
     }
-    ctx.get_coil((CONTEXT_SIZE - 1) as u16).unwrap();
-    match ctx.get_coil(CONTEXT_SIZE as u16) {
+    ctx.get_coil((STORAGE_SIZE - 1) as u16).unwrap();
+    match ctx.get_coil(STORAGE_SIZE as u16) {
         Ok(_) => assert!(false, "oob failed MAX"),
         Err(_) => assert!(true),
     }
-    ctx.set_coil((CONTEXT_SIZE - 1) as u16, true).unwrap();
-    match ctx.set_coil(CONTEXT_SIZE as u16, true) {
+    ctx.set_coil((STORAGE_SIZE - 1) as u16, true).unwrap();
+    match ctx.set_coil(STORAGE_SIZE as u16, true) {
         Ok(_) => assert!(false, "oob failed MAX"),
         Err(_) => assert!(true),
     }
@@ -67,27 +68,27 @@ fn test_std_coil_get_set_bulk() {
 fn test_std_read_discretes_as_bytes_oob() {
     let mut ctx = CTX.write().unwrap();
     let mut result = Vec::new();
-    match ctx.get_discretes_bulk(0, CONTEXT_SIZE as u16 + 1, &mut result) {
+    match ctx.get_discretes_bulk(0, STORAGE_SIZE as u16 + 1, &mut result) {
         Ok(_) => assert!(false, "oob failed 0 - MAX+1 "),
         Err(_) => assert!(true),
     }
-    match ctx.get_discretes_bulk(CONTEXT_SIZE as u16, 1, &mut result) {
+    match ctx.get_discretes_bulk(STORAGE_SIZE as u16, 1, &mut result) {
         Ok(_) => assert!(false, "oob failed MAX - MAX+1"),
         Err(_) => assert!(true),
     }
-    ctx.get_discretes_bulk((CONTEXT_SIZE - 1) as u16, 1, &mut result)
+    ctx.get_discretes_bulk((STORAGE_SIZE - 1) as u16, 1, &mut result)
         .unwrap();
-    match ctx.get_discretes_bulk(CONTEXT_SIZE as u16 - 1, 2, &mut result) {
+    match ctx.get_discretes_bulk(STORAGE_SIZE as u16 - 1, 2, &mut result) {
         Ok(_) => assert!(false, "oob failed MAX - MAX+1"),
         Err(_) => assert!(true),
     }
-    ctx.get_discrete((CONTEXT_SIZE - 1) as u16).unwrap();
-    match ctx.get_discrete(CONTEXT_SIZE as u16) {
+    ctx.get_discrete((STORAGE_SIZE - 1) as u16).unwrap();
+    match ctx.get_discrete(STORAGE_SIZE as u16) {
         Ok(_) => assert!(false, "oob failed MAX"),
         Err(_) => assert!(true),
     }
-    ctx.set_discrete((CONTEXT_SIZE - 1) as u16, true).unwrap();
-    match ctx.set_discrete(CONTEXT_SIZE as u16, true) {
+    ctx.set_discrete((STORAGE_SIZE - 1) as u16, true).unwrap();
+    match ctx.set_discrete(STORAGE_SIZE as u16, true) {
         Ok(_) => assert!(false, "oob failed MAX"),
         Err(_) => assert!(true),
     }
@@ -121,41 +122,41 @@ fn test_std_discrete_get_set_bulk() {
 fn test_std_read_inputs_as_bytes_oob() {
     let mut ctx = CTX.write().unwrap();
     let mut result = Vec::new();
-    match ctx.get_inputs_bulk(0, CONTEXT_SIZE as u16 + 1, &mut result) {
+    match ctx.get_inputs_bulk(0, STORAGE_SIZE as u16 + 1, &mut result) {
         Ok(_) => assert!(false, "oob failed 0 - MAX+1 "),
         Err(_) => assert!(true),
     }
-    match ctx.get_inputs_bulk(CONTEXT_SIZE as u16, 1, &mut result) {
+    match ctx.get_inputs_bulk(STORAGE_SIZE as u16, 1, &mut result) {
         Ok(_) => assert!(false, "oob failed MAX - MAX+1"),
         Err(_) => assert!(true),
     }
-    ctx.get_inputs_bulk((CONTEXT_SIZE - 1) as u16, 1, &mut result)
+    ctx.get_inputs_bulk((STORAGE_SIZE - 1) as u16, 1, &mut result)
         .unwrap();
-    match ctx.get_inputs_bulk(CONTEXT_SIZE as u16 - 1, 2, &mut result) {
+    match ctx.get_inputs_bulk(STORAGE_SIZE as u16 - 1, 2, &mut result) {
         Ok(_) => assert!(false, "oob failed MAX - MAX+1"),
         Err(_) => assert!(true),
     }
-    ctx.get_input((CONTEXT_SIZE - 1) as u16).unwrap();
-    match ctx.get_input(CONTEXT_SIZE as u16) {
+    ctx.get_input((STORAGE_SIZE - 1) as u16).unwrap();
+    match ctx.get_input(STORAGE_SIZE as u16) {
         Ok(_) => assert!(false, "oob failed MAX"),
         Err(_) => assert!(true),
     }
-    ctx.set_input((CONTEXT_SIZE - 1) as u16, 0x55).unwrap();
-    match ctx.set_input(CONTEXT_SIZE as u16, 0x55) {
+    ctx.set_input((STORAGE_SIZE - 1) as u16, 0x55).unwrap();
+    match ctx.set_input(STORAGE_SIZE as u16, 0x55) {
         Ok(_) => assert!(false, "oob failed MAX"),
         Err(_) => assert!(true),
     }
-    match ctx.set_inputs_from_u32((CONTEXT_SIZE - 1) as u16, 0x55) {
+    match ctx.set_inputs_from_u32((STORAGE_SIZE - 1) as u16, 0x55) {
         Ok(_) => assert!(false, "oob failed MAX u32"),
         Err(_) => assert!(true),
     }
-    ctx.set_inputs_from_u32((CONTEXT_SIZE - 2) as u16, 0x9999)
+    ctx.set_inputs_from_u32((STORAGE_SIZE - 2) as u16, 0x9999)
         .unwrap();
-    match ctx.set_inputs_from_u64((CONTEXT_SIZE - 3) as u16, 0x55) {
+    match ctx.set_inputs_from_u64((STORAGE_SIZE - 3) as u16, 0x55) {
         Ok(_) => assert!(false, "oob failed MAX u64"),
         Err(_) => assert!(true),
     }
-    ctx.set_inputs_from_u64((CONTEXT_SIZE - 4) as u16, 0x9999)
+    ctx.set_inputs_from_u64((STORAGE_SIZE - 4) as u16, 0x9999)
         .unwrap();
 }
 
@@ -200,41 +201,41 @@ fn test_std_get_set_inputs() {
 fn test_std_read_holdings_as_bytes_oob() {
     let mut ctx = CTX.write().unwrap();
     let mut result = Vec::new();
-    match ctx.get_holdings_bulk(0, CONTEXT_SIZE as u16 + 1, &mut result) {
+    match ctx.get_holdings_bulk(0, STORAGE_SIZE as u16 + 1, &mut result) {
         Ok(_) => assert!(false, "oob failed 0 - MAX+1 "),
         Err(_) => assert!(true),
     }
-    match ctx.get_holdings_bulk(CONTEXT_SIZE as u16, 1, &mut result) {
+    match ctx.get_holdings_bulk(STORAGE_SIZE as u16, 1, &mut result) {
         Ok(_) => assert!(false, "oob failed MAX - MAX+1"),
         Err(_) => assert!(true),
     }
-    ctx.get_holdings_bulk((CONTEXT_SIZE - 1) as u16, 1, &mut result)
+    ctx.get_holdings_bulk((STORAGE_SIZE - 1) as u16, 1, &mut result)
         .unwrap();
-    match ctx.get_holdings_bulk(CONTEXT_SIZE as u16 - 1, 2, &mut result) {
+    match ctx.get_holdings_bulk(STORAGE_SIZE as u16 - 1, 2, &mut result) {
         Ok(_) => assert!(false, "oob failed MAX - MAX+1"),
         Err(_) => assert!(true),
     }
-    ctx.get_holding((CONTEXT_SIZE - 1) as u16).unwrap();
-    match ctx.get_holding(CONTEXT_SIZE as u16) {
+    ctx.get_holding((STORAGE_SIZE - 1) as u16).unwrap();
+    match ctx.get_holding(STORAGE_SIZE as u16) {
         Ok(_) => assert!(false, "oob failed MAX"),
         Err(_) => assert!(true),
     }
-    ctx.set_holding((CONTEXT_SIZE - 1) as u16, 0x55).unwrap();
-    match ctx.set_holding(CONTEXT_SIZE as u16, 0x55) {
+    ctx.set_holding((STORAGE_SIZE - 1) as u16, 0x55).unwrap();
+    match ctx.set_holding(STORAGE_SIZE as u16, 0x55) {
         Ok(_) => assert!(false, "oob failed MAX"),
         Err(_) => assert!(true),
     }
-    match ctx.set_holdings_from_u32((CONTEXT_SIZE - 1) as u16, 0x55) {
+    match ctx.set_holdings_from_u32((STORAGE_SIZE - 1) as u16, 0x55) {
         Ok(_) => assert!(false, "oob failed MAX u32"),
         Err(_) => assert!(true),
     }
-    ctx.set_holdings_from_u32((CONTEXT_SIZE - 2) as u16, 0x9999)
+    ctx.set_holdings_from_u32((STORAGE_SIZE - 2) as u16, 0x9999)
         .unwrap();
-    match ctx.set_holdings_from_u64((CONTEXT_SIZE - 3) as u16, 0x55) {
+    match ctx.set_holdings_from_u64((STORAGE_SIZE - 3) as u16, 0x55) {
         Ok(_) => assert!(false, "oob failed MAX u64"),
         Err(_) => assert!(true),
     }
-    ctx.set_holdings_from_u64((CONTEXT_SIZE - 4) as u16, 0x9999)
+    ctx.set_holdings_from_u64((STORAGE_SIZE - 4) as u16, 0x9999)
         .unwrap();
 }
 
@@ -440,7 +441,7 @@ fn test_std_frame_fc01_fc02_fc03_fc04_unknown_function() {
     assert_eq!(frame.count, 5);
     assert_eq!(frame.reg, 5);
     assert_eq!(frame.error, 0);
-    frame.process_read(&ctx).unwrap();
+    frame.process_read(&*ctx).unwrap();
     assert_eq!(frame.error, 0);
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
@@ -454,7 +455,7 @@ fn test_std_frame_fc01_fc02_fc03_fc04_unknown_function() {
     assert_eq!(frame.count, 5);
     assert_eq!(frame.reg, 5);
     assert_eq!(frame.error, 0);
-    frame.process_read(&ctx).unwrap();
+    frame.process_read(&*ctx).unwrap();
     assert_eq!(frame.error, 0);
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
@@ -497,7 +498,7 @@ fn test_std_frame_fc01_fc02_fc03_fc04_unknown_function() {
     assert_eq!(frame.response_required, true);
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
-    frame.process_read(&ctx).unwrap();
+    frame.process_read(&*ctx).unwrap();
     assert_eq!(frame.error, 2);
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
@@ -507,7 +508,7 @@ fn test_std_frame_fc01_fc02_fc03_fc04_unknown_function() {
     assert_eq!(frame.response_required, true);
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
-    frame.process_read(&ctx).unwrap();
+    frame.process_read(&*ctx).unwrap();
     assert_eq!(frame.error, 2);
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
@@ -554,7 +555,7 @@ fn test_std_frame_fc01_fc02_fc03_fc04_unknown_function() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, true);
-    frame.process_read(&ctx).unwrap();
+    frame.process_read(&*ctx).unwrap();
     frame.finalize_response().unwrap();
     assert_eq!(
         result.as_slice(),
@@ -576,7 +577,7 @@ fn test_std_frame_fc01_fc02_fc03_fc04_unknown_function() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, true);
-    frame.process_read(&ctx).unwrap();
+    frame.process_read(&*ctx).unwrap();
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
     let framebuf = gen_rtu_frame(&request);
@@ -586,7 +587,7 @@ fn test_std_frame_fc01_fc02_fc03_fc04_unknown_function() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, true);
-    frame.process_read(&ctx).unwrap();
+    frame.process_read(&*ctx).unwrap();
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
     // read inputs
@@ -600,7 +601,7 @@ fn test_std_frame_fc01_fc02_fc03_fc04_unknown_function() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, true);
-    frame.process_read(&ctx).unwrap();
+    frame.process_read(&*ctx).unwrap();
     frame.finalize_response().unwrap();
     assert_eq!(
         result.as_slice(),
@@ -623,7 +624,7 @@ fn test_std_frame_fc05_fc06() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, false);
-    frame.process_write(&mut ctx).unwrap();
+    frame.process_write(&mut *ctx).unwrap();
     assert_eq!(frame.error, 0);
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
@@ -635,7 +636,7 @@ fn test_std_frame_fc05_fc06() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, false);
-    frame.process_write(&mut ctx).unwrap();
+    frame.process_write(&mut *ctx).unwrap();
     assert_eq!(frame.error, 0);
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
@@ -648,7 +649,7 @@ fn test_std_frame_fc05_fc06() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, false);
-    frame.process_write(&mut ctx).unwrap();
+    frame.process_write(&mut *ctx).unwrap();
     assert_eq!(frame.error, 0);
     assert_eq!(ctx.get_coil(5).unwrap(), true);
     let request = [0, 5, 0, 0x7, 0xff, 0];
@@ -659,7 +660,7 @@ fn test_std_frame_fc05_fc06() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, false);
-    frame.process_write(&mut ctx).unwrap();
+    frame.process_write(&mut *ctx).unwrap();
     assert_eq!(frame.error, 0);
     assert_eq!(ctx.get_coil(7).unwrap(), true);
     // write coil invalid data
@@ -672,7 +673,7 @@ fn test_std_frame_fc05_fc06() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, false);
-    frame.process_write(&mut ctx).unwrap();
+    frame.process_write(&mut *ctx).unwrap();
     assert_eq!(frame.error, 3);
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
@@ -686,7 +687,7 @@ fn test_std_frame_fc05_fc06() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, false);
-    frame.process_write(&mut ctx).unwrap();
+    frame.process_write(&mut *ctx).unwrap();
     assert_eq!(frame.error, 2);
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
@@ -697,7 +698,7 @@ fn test_std_frame_fc05_fc06() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, false);
-    frame.process_write(&mut ctx).unwrap();
+    frame.process_write(&mut *ctx).unwrap();
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
     // write holding
@@ -710,7 +711,7 @@ fn test_std_frame_fc05_fc06() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, false);
-    frame.process_write(&mut ctx).unwrap();
+    frame.process_write(&mut *ctx).unwrap();
     assert_eq!(frame.error, 0);
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
@@ -722,7 +723,7 @@ fn test_std_frame_fc05_fc06() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, false);
-    frame.process_write(&mut ctx).unwrap();
+    frame.process_write(&mut *ctx).unwrap();
     assert_eq!(frame.error, 0);
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
@@ -736,7 +737,7 @@ fn test_std_frame_fc05_fc06() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, false);
-    frame.process_write(&mut ctx).unwrap();
+    frame.process_write(&mut *ctx).unwrap();
     assert_eq!(frame.error, 2);
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
@@ -747,7 +748,7 @@ fn test_std_frame_fc05_fc06() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, false);
-    frame.process_write(&mut ctx).unwrap();
+    frame.process_write(&mut *ctx).unwrap();
     assert_eq!(frame.error, 2);
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
@@ -768,7 +769,7 @@ fn test_std_frame_fc15() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, false);
-    frame.process_write(&mut ctx).unwrap();
+    frame.process_write(&mut *ctx).unwrap();
     assert_eq!(frame.error, 0);
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
@@ -785,7 +786,7 @@ fn test_std_frame_fc15() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, false);
-    frame.process_write(&mut ctx).unwrap();
+    frame.process_write(&mut *ctx).unwrap();
     assert_eq!(frame.error, 0);
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
@@ -799,7 +800,7 @@ fn test_std_frame_fc15() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, false);
-    frame.process_write(&mut ctx).unwrap();
+    frame.process_write(&mut *ctx).unwrap();
     assert_eq!(frame.error, 2);
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
@@ -810,7 +811,7 @@ fn test_std_frame_fc15() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, false);
-    frame.process_write(&mut ctx).unwrap();
+    frame.process_write(&mut *ctx).unwrap();
     assert_eq!(frame.error, 2);
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
@@ -834,7 +835,7 @@ fn test_std_frame_fc16() {
     assert_eq!(frame.response_required, true);
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.readonly, false);
-    frame.process_write(&mut ctx).unwrap();
+    frame.process_write(&mut *ctx).unwrap();
     assert_eq!(frame.error, 0);
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
@@ -849,7 +850,7 @@ fn test_std_frame_fc16() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, false);
-    frame.process_write(&mut ctx).unwrap();
+    frame.process_write(&mut *ctx).unwrap();
     assert_eq!(frame.error, 0);
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
@@ -865,7 +866,7 @@ fn test_std_frame_fc16() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, false);
-    frame.process_write(&mut ctx).unwrap();
+    frame.process_write(&mut *ctx).unwrap();
     assert_eq!(frame.error, 2);
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
@@ -876,7 +877,7 @@ fn test_std_frame_fc16() {
     assert_eq!(frame.processing_required, true);
     assert_eq!(frame.error, 0);
     assert_eq!(frame.readonly, false);
-    frame.process_write(&mut ctx).unwrap();
+    frame.process_write(&mut *ctx).unwrap();
     assert_eq!(frame.error, 2);
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
@@ -884,7 +885,7 @@ fn test_std_frame_fc16() {
 
 #[test]
 fn test_modbus_ascii() {
-    let ctx = ModbusContextFull::new();
+    let ctx = ModbusStorageFull::new();
     let mut result = Vec::new();
     let mut ascii_result = Vec::new();
     let request = [
@@ -947,7 +948,7 @@ fn test_std_client() {
         assert_eq!(frame.processing_required, true);
         assert_eq!(frame.error, 0);
         assert_eq!(frame.readonly, false);
-        frame.process_write(&mut ctx).unwrap();
+        frame.process_write(&mut *ctx).unwrap();
         assert_eq!(frame.error, 0);
         frame.finalize_response().unwrap();
         mreq.parse_ok(&response).unwrap();
@@ -980,7 +981,7 @@ fn test_std_client() {
         assert_eq!(frame.processing_required, true);
         assert_eq!(frame.error, 0);
         assert_eq!(frame.readonly, true);
-        frame.process_read(&mut ctx).unwrap();
+        frame.process_read(&mut *ctx).unwrap();
         assert_eq!(frame.error, 0);
         frame.finalize_response().unwrap();
         let mut result = Vec::new();
@@ -1017,7 +1018,7 @@ fn test_std_client() {
         assert_eq!(frame.processing_required, true);
         assert_eq!(frame.error, 0);
         assert_eq!(frame.readonly, true);
-        frame.process_read(&mut ctx).unwrap();
+        frame.process_read(&mut *ctx).unwrap();
         assert_eq!(frame.error, 0);
         frame.finalize_response().unwrap();
         let mut result = Vec::new();
@@ -1050,7 +1051,7 @@ fn test_std_client() {
         assert_eq!(frame.processing_required, true);
         assert_eq!(frame.error, 0);
         assert_eq!(frame.readonly, false);
-        frame.process_write(&mut ctx).unwrap();
+        frame.process_write(&mut *ctx).unwrap();
         assert_eq!(frame.error, 0);
         frame.finalize_response().unwrap();
         mreq.parse_ok(&response).unwrap();
@@ -1080,7 +1081,7 @@ fn test_std_client() {
         assert_eq!(frame.processing_required, true);
         assert_eq!(frame.error, 0);
         assert_eq!(frame.readonly, false);
-        frame.process_write(&mut ctx).unwrap();
+        frame.process_write(&mut *ctx).unwrap();
         assert_eq!(frame.error, 2);
         frame.finalize_response().unwrap();
         assert_eq!(
@@ -1114,7 +1115,7 @@ fn test_std_client() {
         assert_eq!(frame.processing_required, true);
         assert_eq!(frame.error, 0);
         assert_eq!(frame.readonly, false);
-        frame.process_write(&mut ctx).unwrap();
+        frame.process_write(&mut *ctx).unwrap();
         assert_eq!(frame.error, 0);
         frame.finalize_response().unwrap();
         mreq.parse_ok(&response).unwrap();
@@ -1147,7 +1148,7 @@ fn test_std_client() {
         assert_eq!(frame.processing_required, true);
         assert_eq!(frame.error, 0);
         assert_eq!(frame.readonly, true);
-        frame.process_read(&mut ctx).unwrap();
+        frame.process_read(&mut *ctx).unwrap();
         assert_eq!(frame.error, 0);
         frame.finalize_response().unwrap();
         let mut result = Vec::new();
@@ -1180,7 +1181,7 @@ fn test_std_client() {
         assert_eq!(frame.processing_required, true);
         assert_eq!(frame.error, 0);
         assert_eq!(frame.readonly, false);
-        frame.process_write(&mut ctx).unwrap();
+        frame.process_write(&mut *ctx).unwrap();
         assert_eq!(frame.error, 0);
         frame.finalize_response().unwrap();
         mreq.parse_ok(&response).unwrap();
@@ -1210,7 +1211,7 @@ fn test_std_client() {
         assert_eq!(frame.processing_required, true);
         assert_eq!(frame.error, 0);
         assert_eq!(frame.readonly, true);
-        frame.process_read(&mut ctx).unwrap();
+        frame.process_read(&mut *ctx).unwrap();
         assert_eq!(frame.error, 0);
         frame.finalize_response().unwrap();
         let mut result = String::new();
@@ -1247,7 +1248,7 @@ fn test_std_client() {
         assert_eq!(frame.processing_required, true);
         assert_eq!(frame.error, 0);
         assert_eq!(frame.readonly, true);
-        frame.process_read(&mut ctx).unwrap();
+        frame.process_read(&mut *ctx).unwrap();
         assert_eq!(frame.error, 0);
         frame.finalize_response().unwrap();
         let mut result = Vec::new();
@@ -1280,7 +1281,7 @@ fn test_std_client() {
         assert_eq!(frame.processing_required, true);
         assert_eq!(frame.error, 0);
         assert_eq!(frame.readonly, false);
-        frame.process_write(&mut ctx).unwrap();
+        frame.process_write(&mut *ctx).unwrap();
         assert_eq!(frame.error, 0);
         frame.finalize_response().unwrap();
         mreq.parse_ok(&response).unwrap();
@@ -1311,7 +1312,7 @@ fn test_std_client() {
         assert_eq!(frame.processing_required, true);
         assert_eq!(frame.error, 0);
         assert_eq!(frame.readonly, false);
-        frame.process_write(&mut ctx).unwrap();
+        frame.process_write(&mut *ctx).unwrap();
         assert_eq!(frame.error, 2);
         frame.finalize_response().unwrap();
         assert_eq!(


### PR DESCRIPTION
This should fix https://github.com/alttch/rmodbus/issues/23
I need it to myself.
It is a breaking change but allows the usage of rmodbus like before by just changing a few imports.
Maybe they could be a simple way to define a trait  then just coping everything `ModbusContext` had before it but I think to begin with this is still worth having.
Bumped the version to already in this PR.