### PR TITLE
fix parse_slice for write functions

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -316,7 +316,13 @@ impl ModbusRequest {
     /// The input buffer SHOULD be cut to actual response length
     pub fn parse_slice<'a>(&'a self, buf: &'a [u8]) -> Result<&[u8], ErrorKind> {
         let (frame_start, frame_end) = self.parse_response(buf)?;
-        let val = &buf[frame_start + 3..frame_end];
+        let val = match self.func {
+            MODBUS_GET_COILS | MODBUS_GET_DISCRETES | MODBUS_GET_HOLDINGS | MODBUS_GET_INPUTS => {
+                // no data bytes count byte -> skip 1 fewer byte
+                &buf[frame_start + 2..frame_end]
+            },
+            _ => &buf[frame_start + 3..frame_end],
+        };
         Ok(val)
     }
 


### PR DESCRIPTION
Should fix #26.

While write data is usually uninteresting to parse, I need it for error handling and making sure that write functions are received correctly.