### PR TITLE
Fix count in generate_set_holdings_bulk_from_slice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmodbus"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Serhij S. <div@altertech.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -348,7 +348,7 @@ impl ModbusRequest {
     pub fn parse_slice<'a>(&'a self, buf: &'a [u8]) -> Result<&[u8], ErrorKind> {
         let (frame_start, frame_end) = self.parse_response(buf)?;
         let val = match self.func {
-            MODBUS_GET_COILS | MODBUS_GET_DISCRETES | MODBUS_GET_HOLDINGS | MODBUS_GET_INPUTS => {
+            MODBUS_SET_COIL | MODBUS_SET_COILS_BULK | MODBUS_SET_HOLDING | MODBUS_SET_HOLDINGS_BULK => {
                 // no data bytes count byte -> skip 1 fewer byte
                 &buf[frame_start + 2..frame_end]
             }

--- a/src/client.rs
+++ b/src/client.rs
@@ -348,7 +348,10 @@ impl ModbusRequest {
     pub fn parse_slice<'a>(&'a self, buf: &'a [u8]) -> Result<&[u8], ErrorKind> {
         let (frame_start, frame_end) = self.parse_response(buf)?;
         let val = match self.func {
-            MODBUS_SET_COIL | MODBUS_SET_COILS_BULK | MODBUS_SET_HOLDING | MODBUS_SET_HOLDINGS_BULK => {
+            MODBUS_SET_COIL
+            | MODBUS_SET_COILS_BULK
+            | MODBUS_SET_HOLDING
+            | MODBUS_SET_HOLDINGS_BULK => {
                 // no data bytes count byte -> skip 1 fewer byte
                 &buf[frame_start + 2..frame_end]
             }

--- a/src/client.rs
+++ b/src/client.rs
@@ -158,7 +158,7 @@ impl ModbusRequest {
             return Err(ErrorKind::OOB);
         }
         self.reg = reg;
-        self.count = u16::try_from(values.len())?;
+        self.count = u16::try_from((values.len() + 1) / 2)?; // count is number of u16's
         self.func = MODBUS_SET_HOLDINGS_BULK;
         let mut data: ModbusFrameBuf = [0; 256];
         for (i, v) in values.iter().enumerate() {


### PR DESCRIPTION
The `count` field in a `ModbusRequest` is the number of words `u16` in the request body. For `generate_set_holdings_bulk_from_slice`, `count` was instead wrongly set as the number of bytes in the request.