### PR TITLE
Add the RegisterRepresentable trait and related functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,14 @@ let context = ModbusStorage::<128, 16, 0, 100>::new();
 Starting from the version 0.9 it is allowed to provide custom server implementation 
 by implementing `use rmodbus::server::context::ModbusContext` on custom struct.
 For sample implementation have a look at `src/server/storage.rs`
+
+## Custom type representations in `u16` sized registers
+
+Starting from version \<todo: insert version number here\>, you can implement 
+`server::RegisterRepresentable<N>` on your own types and use 
+`ModbusContext::set_*_as_representable` and `ModbusContext::get_*_as_representable`
+methods to directly store and read your own types in the registers.
+
 ## Vectors
 
 Some of rmodbus functions use vectors to store result.  Different vector types can be used:

--- a/src/server/context.rs
+++ b/src/server/context.rs
@@ -1,5 +1,7 @@
 use crate::{ErrorKind, VectorTrait};
 
+use super::representable::RegisterRepresentable;
+
 #[allow(clippy::module_name_repetitions)]
 pub trait ModbusContext {
     /// Get inputs as Vec of u8
@@ -218,4 +220,42 @@ pub trait ModbusContext {
 
     /// Set IEEE 754 f32 to two holding registers
     fn set_holdings_from_f32(&mut self, reg: u16, value: f32) -> Result<(), ErrorKind>;
+
+    /// Get N inputs represented as some [`RegisterRepresentable`] type T
+    ///
+    /// Returns the [`RegisterRepresentable`] once converted using
+    /// [`RegisterRepresentable::from_registers_sequential`]
+    fn get_inputs_as_representable<const N: usize, T: RegisterRepresentable<N>>(
+        &self,
+        reg: u16,
+    ) -> Result<T, ErrorKind>;
+
+    /// Get N holdings represented as some [`RegisterRepresentable`] type T.
+    ///
+    /// Returns the [`RegisterRepresentable`] once converted using
+    /// [`RegisterRepresentable::from_registers_sequential`]
+    fn get_holdings_as_representable<const N: usize, T: RegisterRepresentable<N>>(
+        &self,
+        reg: u16,
+    ) -> Result<T, ErrorKind>;
+
+    /// Set N inputs using a [`RegisterRepresentable`].
+    ///
+    /// Uses [`RegisterRepresentable::to_registers_sequential`] to convert
+    /// type T into a sequence of [`u16`] registers.
+    fn set_inputs_from_representable<const N: usize, T: RegisterRepresentable<N>>(
+        &mut self,
+        reg: u16,
+        value: &T,
+    ) -> Result<(), ErrorKind>;
+
+    /// Set N holdings using a [`RegisterRepresentable`].
+    ///
+    /// Uses [`RegisterRepresentable::to_registers_sequential`] to convert
+    /// type T into a sequence of [`u16`] registers.
+    fn set_holdings_from_representable<const N: usize, T: RegisterRepresentable<N>>(
+        &mut self,
+        reg: u16,
+        value: &T,
+    ) -> Result<(), ErrorKind>;
 }

--- a/src/server/context.rs
+++ b/src/server/context.rs
@@ -228,7 +228,13 @@ pub trait ModbusContext {
     fn get_inputs_as_representable<const N: usize, T: RegisterRepresentable<N>>(
         &self,
         reg: u16,
-    ) -> Result<T, ErrorKind>;
+    ) -> Result<T, ErrorKind> {
+        let mut regs: [u16; N] = [0u16; N];
+        for i in 0..N {
+            regs[i] = self.get_input(reg + i as u16)?;
+        }
+        Ok(T::from_registers_sequential(&regs))
+    }
 
     /// Get N holdings represented as some [`RegisterRepresentable`] type T.
     ///
@@ -237,7 +243,13 @@ pub trait ModbusContext {
     fn get_holdings_as_representable<const N: usize, T: RegisterRepresentable<N>>(
         &self,
         reg: u16,
-    ) -> Result<T, ErrorKind>;
+    ) -> Result<T, ErrorKind> {
+        let mut regs: [u16; N] = [0u16; N];
+        for i in 0..N {
+            regs[i] = self.get_holding(reg + i as u16)?;
+        }
+        Ok(T::from_registers_sequential(&regs))
+    }
 
     /// Set N inputs using a [`RegisterRepresentable`].
     ///
@@ -247,7 +259,10 @@ pub trait ModbusContext {
         &mut self,
         reg: u16,
         value: &T,
-    ) -> Result<(), ErrorKind>;
+    ) -> Result<(), ErrorKind> {
+        let regs = value.to_registers_sequential();
+        self.set_inputs_bulk(reg, &regs)
+    }
 
     /// Set N holdings using a [`RegisterRepresentable`].
     ///
@@ -257,5 +272,8 @@ pub trait ModbusContext {
         &mut self,
         reg: u16,
         value: &T,
-    ) -> Result<(), ErrorKind>;
+    ) -> Result<(), ErrorKind> {
+        let regs = value.to_registers_sequential();
+        self.set_holdings_bulk(reg, &regs)
+    }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2,9 +2,8 @@ pub mod context;
 pub mod representable;
 pub mod storage;
 
-
-pub use representable::representations;
 use core::slice;
+pub use representable::representations;
 
 #[allow(clippy::wildcard_imports)]
 use crate::consts::*;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,4 +1,5 @@
 pub mod context;
+pub mod representable;
 pub mod storage;
 
 use core::slice;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2,6 +2,8 @@ pub mod context;
 pub mod representable;
 pub mod storage;
 
+
+pub use representable::representations;
 use core::slice;
 
 #[allow(clippy::wildcard_imports)]

--- a/src/server/representable.rs
+++ b/src/server/representable.rs
@@ -1,0 +1,95 @@
+/// Implemented for structs that can be represented using N u16 registers.
+/// It is highly recommended that implementors of this type ensure that
+/// [`RegisterRepresentable::to_registers_sequential`] and
+/// [`RegisterRepresentable::from_registers_sequential`] are exact
+/// inverses of each other.
+pub trait RegisterRepresentable<const N: usize> {
+    /// Convert this type into a sequence of `u16`s which can be loaded
+    /// into modbus registers.
+    fn to_registers_sequential(&self) -> [u16; N];
+    /// Extract this type from a sequence of `u16`s taken from sequential
+    /// modbus registers.
+    fn from_registers_sequential(value: &[u16; N]) -> Self;
+}
+
+/// Some implementations of [`RegisterRepresentable`] for convenience.
+/// You can implement [`RegisterRepresentable`] for your custom types
+/// if they aren't implemented here.
+pub mod representations {
+    use super::RegisterRepresentable;
+    #[cfg(feature = "with_bincode")]
+    use bincode::{Decode, Encode};
+    #[cfg(feature = "with_serde")]
+    use serde::{Deserialize, Serialize};
+
+    /// A [`u32`] represented in 2 [`u16`] registers with big endian.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[cfg_attr(feature = "with_serde", derive(Deserialize, Serialize))]
+    #[cfg_attr(feature = "with_bincode", derive(Decode, Encode))]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    pub struct U32BigEndian(pub u32);
+    impl RegisterRepresentable<2> for U32BigEndian {
+        fn to_registers_sequential(&self) -> [u16; 2] {
+            [(self.0 >> 16) as u16, self.0 as u16]
+        }
+        fn from_registers_sequential(value: &[u16; 2]) -> Self {
+            Self(((value[0] as u32) << 16) | (value[1] as u32))
+        }
+    }
+
+    /// A [`u32`] represented in 2 [`u16`] registers with little endian.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[cfg_attr(feature = "with_serde", derive(Deserialize, Serialize))]
+    #[cfg_attr(feature = "with_bincode", derive(Decode, Encode))]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    pub struct U32LittleEndian(pub u32);
+    impl RegisterRepresentable<2> for U32LittleEndian {
+        fn to_registers_sequential(&self) -> [u16; 2] {
+            [self.0 as u16, (self.0 >> 16) as u16]
+        }
+        fn from_registers_sequential(value: &[u16; 2]) -> Self {
+            Self((value[0] as u32) | ((value[1] as u32) << 16))
+        }
+    }
+
+    /// A [`u64`] represented in 2 [`u16`] registers with big endian.
+    pub struct U64BigEndian(pub u64);
+    impl RegisterRepresentable<4> for U64BigEndian {
+        fn to_registers_sequential(&self) -> [u16; 4] {
+            [
+                ((self.0 & 0xFFFF_0000_0000_0000) >> 48) as u16,
+                ((self.0 & 0x0000_FFFF_0000_0000) >> 32) as u16,
+                ((self.0 & 0x0000_0000_FFFF_0000) >> 16) as u16,
+                self.0 as u16,
+            ]
+        }
+        fn from_registers_sequential(value: &[u16; 4]) -> Self {
+            Self(
+                (value[0] as u64) << 48
+                    | (value[1] as u64) << 32
+                    | (value[2] as u64) << 16
+                    | (value[3] as u64),
+            )
+        }
+    }
+    /// A [`u64`] represented in 2 [`u16`] registers with little endian.
+    pub struct U64LittleEndian(pub u64);
+    impl RegisterRepresentable<4> for U64LittleEndian {
+        fn to_registers_sequential(&self) -> [u16; 4] {
+            [
+                self.0 as u16,
+                ((self.0 & 0x0000_0000_FFFF_0000) >> 16) as u16,
+                ((self.0 & 0x0000_FFFF_0000_0000) >> 32) as u16,
+                ((self.0 & 0xFFFF_0000_0000_0000) >> 48) as u16,
+            ]
+        }
+        fn from_registers_sequential(value: &[u16; 4]) -> Self {
+            Self(
+                (value[0] as u64)
+                    | (value[1] as u64) << 16
+                    | (value[2] as u64) << 32
+                    | (value[3] as u64) << 48,
+            )
+        }
+    }
+}

--- a/src/server/representable.rs
+++ b/src/server/representable.rs
@@ -53,6 +53,10 @@ pub mod representations {
     }
 
     /// A [`u64`] represented in 2 [`u16`] registers with big endian.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[cfg_attr(feature = "with_serde", derive(Deserialize, Serialize))]
+    #[cfg_attr(feature = "with_bincode", derive(Decode, Encode))]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct U64BigEndian(pub u64);
     impl RegisterRepresentable<4> for U64BigEndian {
         fn to_registers_sequential(&self) -> [u16; 4] {
@@ -73,6 +77,10 @@ pub mod representations {
         }
     }
     /// A [`u64`] represented in 2 [`u16`] registers with little endian.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[cfg_attr(feature = "with_serde", derive(Deserialize, Serialize))]
+    #[cfg_attr(feature = "with_bincode", derive(Decode, Encode))]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct U64LittleEndian(pub u64);
     impl RegisterRepresentable<4> for U64LittleEndian {
         fn to_registers_sequential(&self) -> [u16; 4] {
@@ -90,6 +98,31 @@ pub mod representations {
                     | (value[2] as u64) << 32
                     | (value[3] as u64) << 48,
             )
+        }
+    }
+
+    /// Tests specifically for the 4 representations provided
+    #[cfg(test)]
+    mod tests {
+        #[allow(clippy::wildcard_imports)]
+        use super::*;
+        #[test]
+        fn test_u32_big_small_endian() {
+            let value: u32 = 0x1111_2222;
+            let big_endian = U32BigEndian(value).to_registers_sequential();
+            let little_endian = U32LittleEndian(value).to_registers_sequential();
+            assert_eq!(big_endian[0], little_endian[1]);
+            assert_eq!(big_endian[1], little_endian[0]);
+        }
+        #[test]
+        fn test_u64_big_small_endian() {
+            let value: u64 = 0x1111_2222_3333_4444;
+            let big_endian = U64BigEndian(value).to_registers_sequential();
+            let little_endian = U64LittleEndian(value).to_registers_sequential();
+            assert_eq!(big_endian[0], little_endian[3]);
+            assert_eq!(big_endian[1], little_endian[2]);
+            assert_eq!(big_endian[2], little_endian[1]);
+            assert_eq!(big_endian[3], little_endian[0]);
         }
     }
 }

--- a/src/server/representable.rs
+++ b/src/server/representable.rs
@@ -16,7 +16,7 @@ pub trait RegisterRepresentable<const N: usize> {
 /// [`Into`] trait is the other side of Rust's [`From`] trait. This
 /// trait is implemented on u16 buffers that can be converted to/from a
 /// [`RegisterRepresentable`] type.
-/// 
+///
 /// This trait is automatically implemented using a blanket impl. Do not
 /// implement this trait manually.
 pub trait RegisterBuffer<const N: usize, T: RegisterRepresentable<N>> {
@@ -44,14 +44,14 @@ impl<const N: usize, T: RegisterRepresentable<N>> RegisterBuffer<N, T> for [u16;
 pub mod representations {
     //! This module contains little and big endian implementations of
     //! storing [`u32`] and [`u64`]s in [`u16`] sized registers.
-    //! 
-    //! Note that "Big Endian" and "Little Endian" in this context means that 
+    //!
+    //! Note that "Big Endian" and "Little Endian" in this context means that
     //! the value is big/small endian with respect to 16 bit words
     //! (registers). This means a `u32` like `0x1122_3344` would be `3344 1122`
-    //! in little endian, not `4433 2211`. 
+    //! in little endian, not `4433 2211`.
     //! The bytes in each word are big endian with respect to each other in the
     //! word.
-    //! 
+    //!
     //! # Example
     //! ```rust
     //! # use rmodbus::server::storage::ModbusStorageFull;
@@ -160,19 +160,25 @@ pub mod representations {
     /// Tests specifically for the 4 representations provided
     #[cfg(test)]
     mod tests {
+        use super::super::RegisterBuffer;
         #[allow(clippy::wildcard_imports)]
         use super::*;
-        use super::super::RegisterBuffer;
         #[test]
         fn test_u32_big_small_endian() {
             let value: u32 = 0x1111_2222;
             let big_endian = U32BigEndian(value).to_registers_sequential();
-            assert_eq!(<[u16; 2] as RegisterBuffer<2, U32BigEndian>>::to_represented(&big_endian), U32BigEndian(value));
+            assert_eq!(
+                <[u16; 2] as RegisterBuffer<2, U32BigEndian>>::to_represented(&big_endian),
+                U32BigEndian(value)
+            );
             let little_endian = U32LittleEndian(value).to_registers_sequential();
-            assert_eq!(<[u16; 2] as RegisterBuffer<2, U32LittleEndian>>::to_represented(&little_endian), U32LittleEndian(value));
+            assert_eq!(
+                <[u16; 2] as RegisterBuffer<2, U32LittleEndian>>::to_represented(&little_endian),
+                U32LittleEndian(value)
+            );
             assert_eq!(big_endian[0], little_endian[1]);
             assert_eq!(big_endian[1], little_endian[0]);
-            
+
             assert_eq!(little_endian[0], 0x2222u16);
             assert_eq!(little_endian[1], 0x1111u16);
         }
@@ -180,9 +186,15 @@ pub mod representations {
         fn test_u64_big_small_endian() {
             let value: u64 = 0x1111_2222_3333_4444;
             let big_endian = U64BigEndian(value).to_registers_sequential();
-            assert_eq!(<[u16; 4] as RegisterBuffer<4, U64BigEndian>>::to_represented(&big_endian), U64BigEndian(value));
+            assert_eq!(
+                <[u16; 4] as RegisterBuffer<4, U64BigEndian>>::to_represented(&big_endian),
+                U64BigEndian(value)
+            );
             let little_endian = U64LittleEndian(value).to_registers_sequential();
-            assert_eq!(<[u16; 4] as RegisterBuffer<4, U64LittleEndian>>::to_represented(&little_endian), U64LittleEndian(value));
+            assert_eq!(
+                <[u16; 4] as RegisterBuffer<4, U64LittleEndian>>::to_represented(&little_endian),
+                U64LittleEndian(value)
+            );
             assert_eq!(big_endian[0], little_endian[3]);
             assert_eq!(big_endian[1], little_endian[2]);
             assert_eq!(big_endian[2], little_endian[1]);

--- a/src/server/storage.rs
+++ b/src/server/storage.rs
@@ -1,7 +1,6 @@
 use super::{
     super::{ErrorKind, VectorTrait},
     context::ModbusContext,
-    representable::RegisterRepresentable,
 };
 #[cfg(feature = "with_bincode")]
 use bincode::{Decode, Encode};
@@ -249,28 +248,6 @@ macro_rules! set_u64 {
             $reg_context[$reg as usize + 2] = ($value >> 16) as u16;
             $reg_context[$reg as usize + 3] = $value as u16;
             Ok(())
-        }
-    };
-}
-
-macro_rules! get_representable {
-    ($reg_context:expr, $reg:expr, $regs_count:expr, $representable_ty:ty, $ctx_size:expr) => {
-        if $reg as usize + $regs_count > $ctx_size {
-            Err(ErrorKind::OOBContext)
-        } else {
-            let regs: &[u16; $regs_count] = $reg_context[($reg as usize)..($reg as usize + $regs_count)].try_into().unwrap();
-            Ok(<$representable_ty as RegisterRepresentable<$regs_count>>::from_registers_sequential(regs))
-        }
-    };
-}
-
-macro_rules! set_representable {
-    ($reg_context:expr, $reg:expr, $regs_count:expr, $value:expr, $ctx_size:expr) => {
-        if $reg as usize + $regs_count > $ctx_size {
-            Err(ErrorKind::OOBContext)
-        } else {
-            let regs: [u16; $regs_count] = $value.to_registers_sequential();
-            set_bulk!($reg_context, $reg, regs, $ctx_size)
         }
     };
 }
@@ -557,47 +534,5 @@ impl<const C: usize, const D: usize, const I: usize, const H: usize> ModbusConte
     #[inline]
     fn set_holdings_from_f32(&mut self, reg: u16, value: f32) -> Result<(), ErrorKind> {
         self.set_holdings_from_u32(reg, value.bits())
-    }
-
-    fn get_inputs_as_representable<
-        const N: usize,
-        T: super::representable::RegisterRepresentable<N>,
-    >(
-        &self,
-        reg: u16,
-    ) -> Result<T, ErrorKind> {
-        get_representable!(self.inputs, reg, N, T, I)
-    }
-
-    fn get_holdings_as_representable<
-        const N: usize,
-        T: super::representable::RegisterRepresentable<N>,
-    >(
-        &self,
-        reg: u16,
-    ) -> Result<T, ErrorKind> {
-        get_representable!(self.holdings, reg, N, T, H)
-    }
-
-    fn set_inputs_from_representable<
-        const N: usize,
-        T: super::representable::RegisterRepresentable<N>,
-    >(
-        &mut self,
-        reg: u16,
-        value: &T,
-    ) -> Result<(), ErrorKind> {
-        set_representable!(self.inputs, reg, N, value, I)
-    }
-
-    fn set_holdings_from_representable<
-        const N: usize,
-        T: super::representable::RegisterRepresentable<N>,
-    >(
-        &mut self,
-        reg: u16,
-        value: &T,
-    ) -> Result<(), ErrorKind> {
-        set_representable!(self.holdings, reg, N, value, H)
     }
 }

--- a/src/tests/test_std.rs
+++ b/src/tests/test_std.rs
@@ -215,34 +215,62 @@ fn test_std_read_inputs_as_bytes_oob() {
     }
     ctx.set_inputs_from_u64(u16::try_from(STORAGE_SIZE - 4).unwrap(), 0x9999)
         .unwrap();
-    if ctx.set_inputs_from_representable(u16::try_from(STORAGE_SIZE - 1).unwrap(), &representations::U32LittleEndian(0x55))
+    if ctx
+        .set_inputs_from_representable(
+            u16::try_from(STORAGE_SIZE - 1).unwrap(),
+            &representations::U32LittleEndian(0x55),
+        )
         .is_ok()
     {
         panic!("{}", "oob failed MAX RegisterRepresentable U32BigEndian")
     }
-    ctx.set_inputs_from_representable(u16::try_from(STORAGE_SIZE - 2).unwrap(), &representations::U32LittleEndian(0x55))
-        .unwrap();
-    if ctx.set_inputs_from_representable(u16::try_from(STORAGE_SIZE - 1).unwrap(), &representations::U32BigEndian(0x55))
+    ctx.set_inputs_from_representable(
+        u16::try_from(STORAGE_SIZE - 2).unwrap(),
+        &representations::U32LittleEndian(0x55),
+    )
+    .unwrap();
+    if ctx
+        .set_inputs_from_representable(
+            u16::try_from(STORAGE_SIZE - 1).unwrap(),
+            &representations::U32BigEndian(0x55),
+        )
         .is_ok()
     {
         panic!("{}", "oob failed MAX RegisterRepresentable U32BigEndian")
     }
-    ctx.set_inputs_from_representable(u16::try_from(STORAGE_SIZE - 2).unwrap(), &representations::U32BigEndian(0x55))
-        .unwrap();
-    if ctx.set_inputs_from_representable(u16::try_from(STORAGE_SIZE - 3).unwrap(), &representations::U64LittleEndian(0x55))
+    ctx.set_inputs_from_representable(
+        u16::try_from(STORAGE_SIZE - 2).unwrap(),
+        &representations::U32BigEndian(0x55),
+    )
+    .unwrap();
+    if ctx
+        .set_inputs_from_representable(
+            u16::try_from(STORAGE_SIZE - 3).unwrap(),
+            &representations::U64LittleEndian(0x55),
+        )
         .is_ok()
     {
         panic!("{}", "oob failed MAX RegisterRepresentable U32BigEndian")
     }
-    ctx.set_inputs_from_representable(u16::try_from(STORAGE_SIZE - 4).unwrap(), &representations::U64LittleEndian(0x55))
-        .unwrap();
-    if ctx.set_inputs_from_representable(u16::try_from(STORAGE_SIZE - 3).unwrap(), &representations::U64BigEndian(0x55))
+    ctx.set_inputs_from_representable(
+        u16::try_from(STORAGE_SIZE - 4).unwrap(),
+        &representations::U64LittleEndian(0x55),
+    )
+    .unwrap();
+    if ctx
+        .set_inputs_from_representable(
+            u16::try_from(STORAGE_SIZE - 3).unwrap(),
+            &representations::U64BigEndian(0x55),
+        )
         .is_ok()
     {
         panic!("{}", "oob failed MAX RegisterRepresentable U32BigEndian")
     }
-    ctx.set_inputs_from_representable(u16::try_from(STORAGE_SIZE - 4).unwrap(), &representations::U64BigEndian(0x55))
-        .unwrap();
+    ctx.set_inputs_from_representable(
+        u16::try_from(STORAGE_SIZE - 4).unwrap(),
+        &representations::U64BigEndian(0x55),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -282,17 +310,37 @@ fn test_std_get_set_inputs() {
     ctx.set_inputs_from_f32(200, 1234.567).unwrap();
     assert_eq!(ctx.get_inputs_as_f32(200).unwrap(), 1234.567f32);
 
-    ctx.set_inputs_from_representable(300, &representations::U32LittleEndian(1234567)).unwrap();
-    assert_eq!(ctx.get_inputs_as_representable::<2, representations::U32LittleEndian>(300).unwrap(), representations::U32LittleEndian(1234567));
+    ctx.set_inputs_from_representable(300, &representations::U32LittleEndian(1234567))
+        .unwrap();
+    assert_eq!(
+        ctx.get_inputs_as_representable::<2, representations::U32LittleEndian>(300)
+            .unwrap(),
+        representations::U32LittleEndian(1234567)
+    );
 
-    ctx.set_inputs_from_representable(300, &representations::U32BigEndian(1234567)).unwrap();
-    assert_eq!(ctx.get_inputs_as_representable::<2, representations::U32BigEndian>(300).unwrap(), representations::U32BigEndian(1234567));
+    ctx.set_inputs_from_representable(300, &representations::U32BigEndian(1234567))
+        .unwrap();
+    assert_eq!(
+        ctx.get_inputs_as_representable::<2, representations::U32BigEndian>(300)
+            .unwrap(),
+        representations::U32BigEndian(1234567)
+    );
 
-    ctx.set_inputs_from_representable(300, &representations::U64BigEndian(1234567)).unwrap();
-    assert_eq!(ctx.get_inputs_as_representable::<4, representations::U64BigEndian>(300).unwrap(), representations::U64BigEndian(1234567));
+    ctx.set_inputs_from_representable(300, &representations::U64BigEndian(1234567))
+        .unwrap();
+    assert_eq!(
+        ctx.get_inputs_as_representable::<4, representations::U64BigEndian>(300)
+            .unwrap(),
+        representations::U64BigEndian(1234567)
+    );
 
-    ctx.set_inputs_from_representable(300, &representations::U64LittleEndian(1234567)).unwrap();
-    assert_eq!(ctx.get_inputs_as_representable::<4, representations::U64LittleEndian>(300).unwrap(), representations::U64LittleEndian(1234567));
+    ctx.set_inputs_from_representable(300, &representations::U64LittleEndian(1234567))
+        .unwrap();
+    assert_eq!(
+        ctx.get_inputs_as_representable::<4, representations::U64LittleEndian>(300)
+            .unwrap(),
+        representations::U64LittleEndian(1234567)
+    );
 }
 
 #[test]
@@ -351,34 +399,62 @@ fn test_std_read_holdings_as_bytes_oob() {
     }
     ctx.set_holdings_from_u64(u16::try_from(STORAGE_SIZE - 4).unwrap(), 0x9999)
         .unwrap();
-    if ctx.set_holdings_from_representable(u16::try_from(STORAGE_SIZE - 1).unwrap(), &representations::U32LittleEndian(0x55))
+    if ctx
+        .set_holdings_from_representable(
+            u16::try_from(STORAGE_SIZE - 1).unwrap(),
+            &representations::U32LittleEndian(0x55),
+        )
         .is_ok()
     {
         panic!("{}", "oob failed MAX RegisterRepresentable U32BigEndian")
     }
-    ctx.set_holdings_from_representable(u16::try_from(STORAGE_SIZE - 2).unwrap(), &representations::U32LittleEndian(0x55))
-        .unwrap();
-    if ctx.set_holdings_from_representable(u16::try_from(STORAGE_SIZE - 1).unwrap(), &representations::U32BigEndian(0x55))
+    ctx.set_holdings_from_representable(
+        u16::try_from(STORAGE_SIZE - 2).unwrap(),
+        &representations::U32LittleEndian(0x55),
+    )
+    .unwrap();
+    if ctx
+        .set_holdings_from_representable(
+            u16::try_from(STORAGE_SIZE - 1).unwrap(),
+            &representations::U32BigEndian(0x55),
+        )
         .is_ok()
     {
         panic!("{}", "oob failed MAX RegisterRepresentable U32BigEndian")
     }
-    ctx.set_holdings_from_representable(u16::try_from(STORAGE_SIZE - 2).unwrap(), &representations::U32BigEndian(0x55))
-        .unwrap();
-    if ctx.set_holdings_from_representable(u16::try_from(STORAGE_SIZE - 3).unwrap(), &representations::U64LittleEndian(0x55))
+    ctx.set_holdings_from_representable(
+        u16::try_from(STORAGE_SIZE - 2).unwrap(),
+        &representations::U32BigEndian(0x55),
+    )
+    .unwrap();
+    if ctx
+        .set_holdings_from_representable(
+            u16::try_from(STORAGE_SIZE - 3).unwrap(),
+            &representations::U64LittleEndian(0x55),
+        )
         .is_ok()
     {
         panic!("{}", "oob failed MAX RegisterRepresentable U32BigEndian")
     }
-    ctx.set_holdings_from_representable(u16::try_from(STORAGE_SIZE - 4).unwrap(), &representations::U64LittleEndian(0x55))
-        .unwrap();
-    if ctx.set_holdings_from_representable(u16::try_from(STORAGE_SIZE - 3).unwrap(), &representations::U64BigEndian(0x55))
+    ctx.set_holdings_from_representable(
+        u16::try_from(STORAGE_SIZE - 4).unwrap(),
+        &representations::U64LittleEndian(0x55),
+    )
+    .unwrap();
+    if ctx
+        .set_holdings_from_representable(
+            u16::try_from(STORAGE_SIZE - 3).unwrap(),
+            &representations::U64BigEndian(0x55),
+        )
         .is_ok()
     {
         panic!("{}", "oob failed MAX RegisterRepresentable U32BigEndian")
     }
-    ctx.set_holdings_from_representable(u16::try_from(STORAGE_SIZE - 4).unwrap(), &representations::U64BigEndian(0x55))
-        .unwrap();
+    ctx.set_holdings_from_representable(
+        u16::try_from(STORAGE_SIZE - 4).unwrap(),
+        &representations::U64BigEndian(0x55),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -417,18 +493,38 @@ fn test_std_get_set_holdings() {
     );
     ctx.set_holdings_from_f32(200, 1234.567).unwrap();
     assert_eq!(ctx.get_holdings_as_f32(200).unwrap(), 1234.567f32);
-    
-    ctx.set_holdings_from_representable(300, &representations::U32LittleEndian(1234567)).unwrap();
-    assert_eq!(ctx.get_holdings_as_representable::<2, representations::U32LittleEndian>(300).unwrap(), representations::U32LittleEndian(1234567));
 
-    ctx.set_holdings_from_representable(300, &representations::U32BigEndian(1234567)).unwrap();
-    assert_eq!(ctx.get_holdings_as_representable::<2, representations::U32BigEndian>(300).unwrap(), representations::U32BigEndian(1234567));
+    ctx.set_holdings_from_representable(300, &representations::U32LittleEndian(1234567))
+        .unwrap();
+    assert_eq!(
+        ctx.get_holdings_as_representable::<2, representations::U32LittleEndian>(300)
+            .unwrap(),
+        representations::U32LittleEndian(1234567)
+    );
 
-    ctx.set_holdings_from_representable(300, &representations::U64BigEndian(1234567)).unwrap();
-    assert_eq!(ctx.get_holdings_as_representable::<4, representations::U64BigEndian>(300).unwrap(), representations::U64BigEndian(1234567));
+    ctx.set_holdings_from_representable(300, &representations::U32BigEndian(1234567))
+        .unwrap();
+    assert_eq!(
+        ctx.get_holdings_as_representable::<2, representations::U32BigEndian>(300)
+            .unwrap(),
+        representations::U32BigEndian(1234567)
+    );
 
-    ctx.set_holdings_from_representable(300, &representations::U64LittleEndian(1234567)).unwrap();
-    assert_eq!(ctx.get_holdings_as_representable::<4, representations::U64LittleEndian>(300).unwrap(), representations::U64LittleEndian(1234567));
+    ctx.set_holdings_from_representable(300, &representations::U64BigEndian(1234567))
+        .unwrap();
+    assert_eq!(
+        ctx.get_holdings_as_representable::<4, representations::U64BigEndian>(300)
+            .unwrap(),
+        representations::U64BigEndian(1234567)
+    );
+
+    ctx.set_holdings_from_representable(300, &representations::U64LittleEndian(1234567))
+        .unwrap();
+    assert_eq!(
+        ctx.get_holdings_as_representable::<4, representations::U64LittleEndian>(300)
+            .unwrap(),
+        representations::U64LittleEndian(1234567)
+    );
 }
 
 #[test]

--- a/src/tests/test_std.rs
+++ b/src/tests/test_std.rs
@@ -9,6 +9,7 @@ use crate::*;
 #[allow(clippy::wildcard_imports)]
 use crc16::*;
 use once_cell::sync::Lazy;
+use representable::representations;
 use std::sync::RwLock;
 
 static CTX: Lazy<RwLock<ModbusStorageFull>> = Lazy::new(<_>::default);
@@ -214,6 +215,34 @@ fn test_std_read_inputs_as_bytes_oob() {
     }
     ctx.set_inputs_from_u64(u16::try_from(STORAGE_SIZE - 4).unwrap(), 0x9999)
         .unwrap();
+    if ctx.set_inputs_from_representable(u16::try_from(STORAGE_SIZE - 1).unwrap(), &representations::U32LittleEndian(0x55))
+        .is_ok()
+    {
+        panic!("{}", "oob failed MAX RegisterRepresentable U32BigEndian")
+    }
+    ctx.set_inputs_from_representable(u16::try_from(STORAGE_SIZE - 2).unwrap(), &representations::U32LittleEndian(0x55))
+        .unwrap();
+    if ctx.set_inputs_from_representable(u16::try_from(STORAGE_SIZE - 1).unwrap(), &representations::U32BigEndian(0x55))
+        .is_ok()
+    {
+        panic!("{}", "oob failed MAX RegisterRepresentable U32BigEndian")
+    }
+    ctx.set_inputs_from_representable(u16::try_from(STORAGE_SIZE - 2).unwrap(), &representations::U32BigEndian(0x55))
+        .unwrap();
+    if ctx.set_inputs_from_representable(u16::try_from(STORAGE_SIZE - 3).unwrap(), &representations::U64LittleEndian(0x55))
+        .is_ok()
+    {
+        panic!("{}", "oob failed MAX RegisterRepresentable U32BigEndian")
+    }
+    ctx.set_inputs_from_representable(u16::try_from(STORAGE_SIZE - 4).unwrap(), &representations::U64LittleEndian(0x55))
+        .unwrap();
+    if ctx.set_inputs_from_representable(u16::try_from(STORAGE_SIZE - 3).unwrap(), &representations::U64BigEndian(0x55))
+        .is_ok()
+    {
+        panic!("{}", "oob failed MAX RegisterRepresentable U32BigEndian")
+    }
+    ctx.set_inputs_from_representable(u16::try_from(STORAGE_SIZE - 4).unwrap(), &representations::U64BigEndian(0x55))
+        .unwrap();
 }
 
 #[test]
@@ -252,6 +281,18 @@ fn test_std_get_set_inputs() {
     );
     ctx.set_inputs_from_f32(200, 1234.567).unwrap();
     assert_eq!(ctx.get_inputs_as_f32(200).unwrap(), 1234.567f32);
+
+    ctx.set_inputs_from_representable(300, &representations::U32LittleEndian(1234567)).unwrap();
+    assert_eq!(ctx.get_inputs_as_representable::<2, representations::U32LittleEndian>(300).unwrap(), representations::U32LittleEndian(1234567));
+
+    ctx.set_inputs_from_representable(300, &representations::U32BigEndian(1234567)).unwrap();
+    assert_eq!(ctx.get_inputs_as_representable::<2, representations::U32BigEndian>(300).unwrap(), representations::U32BigEndian(1234567));
+
+    ctx.set_inputs_from_representable(300, &representations::U64BigEndian(1234567)).unwrap();
+    assert_eq!(ctx.get_inputs_as_representable::<4, representations::U64BigEndian>(300).unwrap(), representations::U64BigEndian(1234567));
+
+    ctx.set_inputs_from_representable(300, &representations::U64LittleEndian(1234567)).unwrap();
+    assert_eq!(ctx.get_inputs_as_representable::<4, representations::U64LittleEndian>(300).unwrap(), representations::U64LittleEndian(1234567));
 }
 
 #[test]
@@ -310,6 +351,34 @@ fn test_std_read_holdings_as_bytes_oob() {
     }
     ctx.set_holdings_from_u64(u16::try_from(STORAGE_SIZE - 4).unwrap(), 0x9999)
         .unwrap();
+    if ctx.set_holdings_from_representable(u16::try_from(STORAGE_SIZE - 1).unwrap(), &representations::U32LittleEndian(0x55))
+        .is_ok()
+    {
+        panic!("{}", "oob failed MAX RegisterRepresentable U32BigEndian")
+    }
+    ctx.set_holdings_from_representable(u16::try_from(STORAGE_SIZE - 2).unwrap(), &representations::U32LittleEndian(0x55))
+        .unwrap();
+    if ctx.set_holdings_from_representable(u16::try_from(STORAGE_SIZE - 1).unwrap(), &representations::U32BigEndian(0x55))
+        .is_ok()
+    {
+        panic!("{}", "oob failed MAX RegisterRepresentable U32BigEndian")
+    }
+    ctx.set_holdings_from_representable(u16::try_from(STORAGE_SIZE - 2).unwrap(), &representations::U32BigEndian(0x55))
+        .unwrap();
+    if ctx.set_holdings_from_representable(u16::try_from(STORAGE_SIZE - 3).unwrap(), &representations::U64LittleEndian(0x55))
+        .is_ok()
+    {
+        panic!("{}", "oob failed MAX RegisterRepresentable U32BigEndian")
+    }
+    ctx.set_holdings_from_representable(u16::try_from(STORAGE_SIZE - 4).unwrap(), &representations::U64LittleEndian(0x55))
+        .unwrap();
+    if ctx.set_holdings_from_representable(u16::try_from(STORAGE_SIZE - 3).unwrap(), &representations::U64BigEndian(0x55))
+        .is_ok()
+    {
+        panic!("{}", "oob failed MAX RegisterRepresentable U32BigEndian")
+    }
+    ctx.set_holdings_from_representable(u16::try_from(STORAGE_SIZE - 4).unwrap(), &representations::U64BigEndian(0x55))
+        .unwrap();
 }
 
 #[test]
@@ -348,6 +417,18 @@ fn test_std_get_set_holdings() {
     );
     ctx.set_holdings_from_f32(200, 1234.567).unwrap();
     assert_eq!(ctx.get_holdings_as_f32(200).unwrap(), 1234.567f32);
+    
+    ctx.set_holdings_from_representable(300, &representations::U32LittleEndian(1234567)).unwrap();
+    assert_eq!(ctx.get_holdings_as_representable::<2, representations::U32LittleEndian>(300).unwrap(), representations::U32LittleEndian(1234567));
+
+    ctx.set_holdings_from_representable(300, &representations::U32BigEndian(1234567)).unwrap();
+    assert_eq!(ctx.get_holdings_as_representable::<2, representations::U32BigEndian>(300).unwrap(), representations::U32BigEndian(1234567));
+
+    ctx.set_holdings_from_representable(300, &representations::U64BigEndian(1234567)).unwrap();
+    assert_eq!(ctx.get_holdings_as_representable::<4, representations::U64BigEndian>(300).unwrap(), representations::U64BigEndian(1234567));
+
+    ctx.set_holdings_from_representable(300, &representations::U64LittleEndian(1234567)).unwrap();
+    assert_eq!(ctx.get_holdings_as_representable::<4, representations::U64LittleEndian>(300).unwrap(), representations::U64LittleEndian(1234567));
 }
 
 #[test]


### PR DESCRIPTION
This PR adds the `RegisterRepresentable` trait described in https://github.com/alttch/rmodbus/issues/36. 

It also adds:
- `U32LittleEndian`, `U32BigEndian`, `U64LittleEndian` and `U64BigEndian` as implementors of that trait.
  - Some test code in the tests module
  - Some module level documentation
- `RegisterBuffer<const N: usize, T: RegisterRepresentable<N>>` which is automatically implemented on buffers that
  `RegisterRepresentable` can be converted to.
- A small note in the `README.md` file about custom types implementing `RegisterRepresentable`.

This PR is **not** ready yet, because the `README.md` has a `<todo: insert version number here>` spot where it
describes when `RegisterRepresentable` was added. The `Cargo.toml` version number also hasn't been updated because I'm not
sure how/if you would like to increase the version numbers now.