### PR TITLE
Use `core::error::Error` instead of the `std` Implementation

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.68.0"
+channel = "1.81.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -122,5 +122,4 @@ impl From<TryFromIntError> for ErrorKind {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ErrorKind {}
+impl core::error::Error for ErrorKind {}


### PR DESCRIPTION
This should support better error handling for `no_std` environments, but we do have to bump the toolchain version to at least 1.81.0.