### PR TITLE
Use enums instead of constants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,3 +78,21 @@ required-features = ["std"]
 name = "tcpclient"
 path = "examples/tcpclient.rs"
 required-features = ["std"]
+
+[lints.clippy]
+# all = "warn"
+pedantic = { level = "warn", priority = -1 }
+used-underscore-binding = "allow"
+doc_markdown = "allow"
+needless_pass_by_value = "allow"
+must_use_candidate = "allow"
+return_self_not_must_use = "allow"
+missing_errors_doc = "allow"
+single_match = "allow"
+uninlined_format_args = "allow"
+no_effect_underscore_binding = "allow"
+large_futures = "allow"
+precedence = "allow"
+manual_div_ceil = "allow"
+non_std_lazy_statics = "allow"
+manual_slice_fill = "allow"

--- a/README.md
+++ b/README.md
@@ -285,60 +285,58 @@ use std::time::Duration;
 
 use rmodbus::{client::ModbusRequest, guess_response_frame_len, ModbusProto};
 
-fn main() {
-    let timeout = Duration::from_secs(1);
+let timeout = Duration::from_secs(1);
 
-    // open TCP connection
-    let mut stream = TcpStream::connect("localhost:5502").unwrap();
-    stream.set_read_timeout(Some(timeout)).unwrap();
-    stream.set_write_timeout(Some(timeout)).unwrap();
+// open TCP connection
+let mut stream = TcpStream::connect("localhost:5502").unwrap();
+stream.set_read_timeout(Some(timeout)).unwrap();
+stream.set_write_timeout(Some(timeout)).unwrap();
 
-    // create request object
-    let mut mreq = ModbusRequest::new(1, ModbusProto::TcpUdp);
-    mreq.tr_id = 2; // just for test, default tr_id is 1
+// create request object
+let mut mreq = ModbusRequest::new(1, ModbusProto::TcpUdp);
+mreq.tr_id = 2; // just for test, default tr_id is 1
 
-    // set 2 coils
-    let mut request = Vec::new();
-    mreq.generate_set_coils_bulk(0, &[true, true], &mut request)
-        .unwrap();
+// set 2 coils
+let mut request = Vec::new();
+mreq.generate_set_coils_bulk(0, &[true, true], &mut request)
+    .unwrap();
 
-    // write request to stream
-    stream.write(&request).unwrap();
+// write request to stream
+stream.write(&request).unwrap();
 
-    // read first 6 bytes of response frame
-    let mut buf = [0u8; 6];
-    stream.read_exact(&mut buf).unwrap();
-    let mut response = Vec::new();
-    response.extend_from_slice(&buf);
-    let len = guess_response_frame_len(&buf, ModbusProto::TcpUdp).unwrap();
-    // read rest of response frame
-    if len > 6 {
-        let mut rest = vec![0u8; (len - 6) as usize];
-        stream.read_exact(&mut rest).unwrap();
-        response.extend(rest);
-    }
-    // check if frame has no Modbus error inside
-    mreq.parse_ok(&response).unwrap();
+// read first 6 bytes of response frame
+let mut buf = [0u8; 6];
+stream.read_exact(&mut buf).unwrap();
+let mut response = Vec::new();
+response.extend_from_slice(&buf);
+let len = guess_response_frame_len(&buf, ModbusProto::TcpUdp).unwrap();
+// read rest of response frame
+if len > 6 {
+    let mut rest = vec![0u8; (len - 6) as usize];
+    stream.read_exact(&mut rest).unwrap();
+    response.extend(rest);
+}
+// check if frame has no Modbus error inside
+mreq.parse_ok(&response).unwrap();
 
-    // get coil values back
-    mreq.generate_get_coils(0, 2, &mut request).unwrap();
-    stream.write(&request).unwrap();
-    let mut buf = [0u8; 6];
-    stream.read_exact(&mut buf).unwrap();
-    let mut response = Vec::new();
-    response.extend_from_slice(&buf);
-    let len = guess_response_frame_len(&buf, ModbusProto::TcpUdp).unwrap();
-    if len > 6 {
-        let mut rest = vec![0u8; (len - 6) as usize];
-        stream.read_exact(&mut rest).unwrap();
-        response.extend(rest);
-    }
-    let mut data = Vec::new();
-    // check if frame has no Modbus error inside and parse response bools into data vec
-    mreq.parse_bool(&response, &mut data).unwrap();
-    for i in 0..data.len() {
-        println!("{} {}", i, data[i]);
-    }
+// get coil values back
+mreq.generate_get_coils(0, 2, &mut request).unwrap();
+stream.write(&request).unwrap();
+let mut buf = [0u8; 6];
+stream.read_exact(&mut buf).unwrap();
+let mut response = Vec::new();
+response.extend_from_slice(&buf);
+let len = guess_response_frame_len(&buf, ModbusProto::TcpUdp).unwrap();
+if len > 6 {
+    let mut rest = vec![0u8; (len - 6) as usize];
+    stream.read_exact(&mut rest).unwrap();
+    response.extend(rest);
+}
+let mut data = Vec::new();
+// check if frame has no Modbus error inside and parse response bools into data vec
+mreq.parse_bool(&response, &mut data).unwrap();
+for i in 0..data.len() {
+    println!("{} {}", i, data[i]);
 }
 ```
 ## About the authors

--- a/src/client.rs
+++ b/src/client.rs
@@ -438,9 +438,6 @@ impl ModbusRequest {
             ModbusFunction::SetCoil
             | ModbusFunction::SetHolding => {
                 request.extend(data)?;
-                // for v in data {
-                //     request.push(*v)?;
-                // }
             }
             ModbusFunction::SetCoilsBulk
             | ModbusFunction::SetHoldingsBulk => {
@@ -451,9 +448,7 @@ impl ModbusRequest {
                 }
                 #[allow(clippy::cast_possible_truncation)]
                 request.push(l as u8)?;
-                for v in data {
-                    request.push(*v)?;
-                }
+                request.extend(data)?;
             }
         }
         match self.proto {

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,16 +1,136 @@
 //! MODBUS Constants
 
-// MODBUS Functions
-pub const MODBUS_GET_COILS: u8 = 1;
-pub const MODBUS_GET_DISCRETES: u8 = 2;
-pub const MODBUS_GET_HOLDINGS: u8 = 3;
-pub const MODBUS_GET_INPUTS: u8 = 4;
-pub const MODBUS_SET_COIL: u8 = 5;
-pub const MODBUS_SET_HOLDING: u8 = 6;
-pub const MODBUS_SET_COILS_BULK: u8 = 15;
-pub const MODBUS_SET_HOLDINGS_BULK: u8 = 16;
+/// MODBUS Functions
+///
+/// Some useful terminology:
+///
+/// - `Coil`: read/write, 1 bit
+/// - `Discrete Input`: read-only, 1 bit
+/// - `Input Register`: read-only, 16 bits (1 word)
+/// - `Holding Register`: read/write, 16 bits (1 word)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ModbusFunction {
+    /// Get Multiple Coils (Code = `0x01`)
+    GetCoils = 0x01,
+    /// Get Discrete inputs (Code = `0x02`)
+    GetDiscretes = 0x02,
+    /// Get Holdings (Code = `0x03`)
+    GetHoldings = 0x03,
+    /// Get Multiple Inputs registers (Code = `0x04`)
+    GetInputs = 0x04,
+    /// Set Single Coil (Code = `0x05`)
+    SetCoil = 0x05,
+    /// Set Single Holding Register (Code = `0x06`)
+    SetHolding = 0x06,
+    /// Set Coils Bulk (Code = `0x0F`)
+    SetCoilsBulk = 0x0F,
+    /// Set Holdings Bulk (Code = `0x10`)
+    SetHoldingsBulk = 0x10,
+}
 
-// MODBUS Errors
-pub const MODBUS_ERROR_ILLEGAL_FUNCTION: u8 = 1;
-pub const MODBUS_ERROR_ILLEGAL_DATA_ADDRESS: u8 = 2;
-pub const MODBUS_ERROR_ILLEGAL_DATA_VALUE: u8 = 3;
+impl TryFrom<u8> for ModbusFunction {
+    type Error = crate::ErrorKind;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x01 => Ok(ModbusFunction::GetCoils),
+            0x02 => Ok(ModbusFunction::GetDiscretes),
+            0x03 => Ok(ModbusFunction::GetHoldings),
+            0x04 => Ok(ModbusFunction::GetInputs),
+            0x05 => Ok(ModbusFunction::SetCoil),
+            0x06 => Ok(ModbusFunction::SetHolding),
+            0x0F => Ok(ModbusFunction::SetCoilsBulk),
+            0x10 => Ok(ModbusFunction::SetHoldingsBulk),
+            _ => Err(crate::ErrorKind::IllegalFunction),
+        }
+    }
+}
+
+impl ModbusFunction {
+    /// Returns the function code that corresponds to this function as a byte.
+    pub fn byte(&self) -> u8 {
+        *self as u8
+    }
+
+    /// Returns whether this function is a read (`GET`) operation
+    pub fn is_read(&self) -> bool {
+        matches!(
+            self,
+            ModbusFunction::GetCoils
+                | ModbusFunction::GetDiscretes
+                | ModbusFunction::GetHoldings
+                | ModbusFunction::GetInputs
+        )
+    }
+
+    /// Returns whether this function is a write (`SET`) operation
+    pub fn is_write(&self) -> bool {
+        matches!(
+            self,
+            ModbusFunction::SetCoil
+                | ModbusFunction::SetHolding
+                | ModbusFunction::SetCoilsBulk
+                | ModbusFunction::SetHoldingsBulk
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum ModbusErrorCode {
+    NoError = 0x00,
+    IllegalFunction = 0x01,
+    IllegalDataAddress = 0x02,
+    IllegalDataValue = 0x03,
+    SlaveDeviceFailure = 0x04,
+    Acknowledge = 0x05,
+    SlaveDeviceBusy = 0x06,
+    NegativeAcknowledge = 0x07,
+    MemoryParityError = 0x08,
+    GatewayPathUnavailable = 0x09,
+    GatewayTargetFailed = 0x0A,
+    InvalidCrc = 0x15,
+}
+
+impl TryFrom<u8> for ModbusErrorCode {
+    type Error = crate::ErrorKind;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x00 => Ok(ModbusErrorCode::NoError),
+            0x01 => Ok(ModbusErrorCode::IllegalFunction),
+            0x02 => Ok(ModbusErrorCode::IllegalDataAddress),
+            0x03 => Ok(ModbusErrorCode::IllegalDataValue),
+            0x04 => Ok(ModbusErrorCode::SlaveDeviceFailure),
+            0x05 => Ok(ModbusErrorCode::Acknowledge),
+            0x06 => Ok(ModbusErrorCode::SlaveDeviceBusy),
+            0x07 => Ok(ModbusErrorCode::NegativeAcknowledge),
+            0x08 => Ok(ModbusErrorCode::MemoryParityError),
+            0x09 => Ok(ModbusErrorCode::GatewayPathUnavailable),
+            0x0A => Ok(ModbusErrorCode::GatewayTargetFailed),
+            _ => Err(crate::ErrorKind::UnknownError),
+        }
+    }
+}
+
+impl ModbusErrorCode {
+    /// Returns the error code as a byte.
+    pub fn byte(&self) -> u8 {
+        *self as u8
+    }
+}
+
+// pub const MODBUS_GET_COILS: u8 = 1;
+// pub const MODBUS_GET_DISCRETES: u8 = 2;
+// pub const MODBUS_GET_HOLDINGS: u8 = 3;
+// pub const MODBUS_GET_INPUTS: u8 = 4;
+// pub const MODBUS_SET_COIL: u8 = 5;
+// pub const MODBUS_SET_HOLDING: u8 = 6;
+// pub const MODBUS_SET_COILS_BULK: u8 = 15;
+// pub const MODBUS_SET_HOLDINGS_BULK: u8 = 16;
+
+// // MODBUS Errors
+// pub const MODBUS_ERROR_ILLEGAL_FUNCTION: u8 = 1;
+// pub const MODBUS_ERROR_ILLEGAL_DATA_ADDRESS: u8 = 2;
+// pub const MODBUS_ERROR_ILLEGAL_DATA_VALUE: u8 = 3;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 use core::num::TryFromIntError;
 
+use crate::consts::ModbusErrorCode;
+
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -61,21 +63,22 @@ impl ErrorKind {
         )
     }
 
-    pub fn to_modbus_error(&self) -> Result<u8, ErrorKind> {
+    pub fn to_modbus_error(&self) -> Result<ModbusErrorCode, ErrorKind> {
         #[allow(clippy::enum_glob_use)]
         use ErrorKind::*;
 
         match self {
-            IllegalFunction => Ok(1),
-            IllegalDataAddress => Ok(2),
-            IllegalDataValue => Ok(3),
-            SlaveDeviceFailure => Ok(4),
-            Acknowledge => Ok(5),
-            SlaveDeviceBusy => Ok(6),
-            NegativeAcknowledge => Ok(7),
-            MemoryParityError => Ok(8),
-            GatewayPathUnavailable => Ok(9),
-            GatewayTargetFailed => Ok(10),
+            IllegalFunction => Ok(ModbusErrorCode::IllegalFunction),
+            IllegalDataAddress => Ok(ModbusErrorCode::IllegalDataAddress),
+            IllegalDataValue => Ok(ModbusErrorCode::IllegalDataValue),
+            SlaveDeviceFailure => Ok(ModbusErrorCode::SlaveDeviceFailure),
+            Acknowledge => Ok(ModbusErrorCode::Acknowledge),
+            SlaveDeviceBusy => Ok(ModbusErrorCode::SlaveDeviceBusy),
+            NegativeAcknowledge => Ok(ModbusErrorCode::NegativeAcknowledge),
+            MemoryParityError => Ok(ModbusErrorCode::MemoryParityError),
+            GatewayPathUnavailable => Ok(ModbusErrorCode::GatewayPathUnavailable),
+            GatewayTargetFailed => Ok(ModbusErrorCode::GatewayTargetFailed),
+            CommunicationError => Ok(ModbusErrorCode::InvalidCrc),
             _ => Err(*self),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,40 +45,35 @@ impl ErrorKind {
     }
 
     pub fn is_modbus_error(&self) -> bool {
-        #[allow(clippy::enum_glob_use)]
-        use ErrorKind::*;
-
         matches!(
             self,
-            IllegalFunction
-                | IllegalDataAddress
-                | IllegalDataValue
-                | SlaveDeviceFailure
-                | Acknowledge
-                | SlaveDeviceBusy
-                | NegativeAcknowledge
-                | MemoryParityError
-                | GatewayPathUnavailable
-                | GatewayTargetFailed
+            Self::IllegalFunction
+                | Self::IllegalDataAddress
+                | Self::IllegalDataValue
+                | Self::SlaveDeviceFailure
+                | Self::Acknowledge
+                | Self::SlaveDeviceBusy
+                | Self::NegativeAcknowledge
+                | Self::MemoryParityError
+                | Self::GatewayPathUnavailable
+                | Self::GatewayTargetFailed
+                | Self::CommunicationError
         )
     }
 
     pub fn to_modbus_error(&self) -> Result<ModbusErrorCode, ErrorKind> {
-        #[allow(clippy::enum_glob_use)]
-        use ErrorKind::*;
-
         match self {
-            IllegalFunction => Ok(ModbusErrorCode::IllegalFunction),
-            IllegalDataAddress => Ok(ModbusErrorCode::IllegalDataAddress),
-            IllegalDataValue => Ok(ModbusErrorCode::IllegalDataValue),
-            SlaveDeviceFailure => Ok(ModbusErrorCode::SlaveDeviceFailure),
-            Acknowledge => Ok(ModbusErrorCode::Acknowledge),
-            SlaveDeviceBusy => Ok(ModbusErrorCode::SlaveDeviceBusy),
-            NegativeAcknowledge => Ok(ModbusErrorCode::NegativeAcknowledge),
-            MemoryParityError => Ok(ModbusErrorCode::MemoryParityError),
-            GatewayPathUnavailable => Ok(ModbusErrorCode::GatewayPathUnavailable),
-            GatewayTargetFailed => Ok(ModbusErrorCode::GatewayTargetFailed),
-            CommunicationError => Ok(ModbusErrorCode::InvalidCrc),
+            Self::IllegalFunction => Ok(ModbusErrorCode::IllegalFunction),
+            Self::IllegalDataAddress => Ok(ModbusErrorCode::IllegalDataAddress),
+            Self::IllegalDataValue => Ok(ModbusErrorCode::IllegalDataValue),
+            Self::SlaveDeviceFailure => Ok(ModbusErrorCode::SlaveDeviceFailure),
+            Self::Acknowledge => Ok(ModbusErrorCode::Acknowledge),
+            Self::SlaveDeviceBusy => Ok(ModbusErrorCode::SlaveDeviceBusy),
+            Self::NegativeAcknowledge => Ok(ModbusErrorCode::NegativeAcknowledge),
+            Self::MemoryParityError => Ok(ModbusErrorCode::MemoryParityError),
+            Self::GatewayPathUnavailable => Ok(ModbusErrorCode::GatewayPathUnavailable),
+            Self::GatewayTargetFailed => Ok(ModbusErrorCode::GatewayTargetFailed),
+            Self::CommunicationError => Ok(ModbusErrorCode::InvalidCrc),
             _ => Err(*self),
         }
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -244,7 +244,7 @@ impl<'a, V: VectorTrait<u8>> ModbusFrame<'a, V> {
     /// [`ModbusContext`](context::ModbusContext)) don't forget to call
     /// [`process_external_write`](ModbusFrame::process_external_write), these two calls together
     /// replace the call to [`process_write`](ModbusFrame::process_write).
-    pub fn get_external_write(&mut self) -> Result<Write, ErrorKind> {
+    pub fn get_external_write(&'a mut self) -> Result<Write<'a>, ErrorKind> {
         match self.func {
             ModbusFunction::SetCoil => {
                 // func 5
@@ -442,7 +442,7 @@ impl<'a, V: VectorTrait<u8>> ModbusFrame<'a, V> {
     /// [`ModbusContext`](context::ModbusContext)) don't forget to call
     /// [`process_external_read`](ModbusFrame::process_external_read), these two calls together
     /// replace the call to [`process_read`](ModbusFrame::process_read).
-    pub fn get_external_read(&mut self) -> Result<Read, ErrorKind> {
+    pub fn get_external_read(&'a mut self) -> Result<Read<'a>, ErrorKind> {
         match self.func {
             ModbusFunction::GetCoils | ModbusFunction::GetDiscretes => {
                 // funcs 1 - 2

--- a/src/server/representable.rs
+++ b/src/server/representable.rs
@@ -129,10 +129,10 @@ pub mod representations {
         }
         fn from_registers_sequential(value: &[u16; 4]) -> Self {
             Self(
-                (u64::from(value[0])) << 48
-                    | (u64::from(value[1])) << 32
-                    | (u64::from(value[2])) << 16
-                    | (u64::from(value[3])),
+                (u64::from(value[0]) << 48)
+                | (u64::from(value[1]) << 32)
+                | (u64::from(value[2]) << 16)
+                | u64::from(value[3]),
             )
         }
     }
@@ -154,10 +154,10 @@ pub mod representations {
         }
         fn from_registers_sequential(value: &[u16; 4]) -> Self {
             Self(
-                (u64::from(value[0]))
-                    | (u64::from(value[1])) << 16
-                    | (u64::from(value[2])) << 32
-                    | (u64::from(value[3])) << 48,
+                u64::from(value[0])
+                | (u64::from(value[1]) << 16)
+                | (u64::from(value[2]) << 32)
+                | (u64::from(value[3]) << 48),
             )
         }
     }

--- a/src/server/representable.rs
+++ b/src/server/representable.rs
@@ -130,9 +130,9 @@ pub mod representations {
         fn from_registers_sequential(value: &[u16; 4]) -> Self {
             Self(
                 (u64::from(value[0]) << 48)
-                | (u64::from(value[1]) << 32)
-                | (u64::from(value[2]) << 16)
-                | u64::from(value[3]),
+                    | (u64::from(value[1]) << 32)
+                    | (u64::from(value[2]) << 16)
+                    | u64::from(value[3]),
             )
         }
     }
@@ -155,9 +155,9 @@ pub mod representations {
         fn from_registers_sequential(value: &[u16; 4]) -> Self {
             Self(
                 u64::from(value[0])
-                | (u64::from(value[1]) << 16)
-                | (u64::from(value[2]) << 32)
-                | (u64::from(value[3]) << 48),
+                    | (u64::from(value[1]) << 16)
+                    | (u64::from(value[2]) << 32)
+                    | (u64::from(value[3]) << 48),
             )
         }
     }

--- a/src/tests/test_nostd.rs
+++ b/src/tests/test_nostd.rs
@@ -195,10 +195,10 @@ fn test_nostd_frame() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(frame.readonly);
     frame.process_read(&*ctx).unwrap();
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
     //check result OOB
@@ -265,10 +265,10 @@ fn test_nostd_client() {
         frame.parse().unwrap();
         assert!(frame.response_required);
         assert!(frame.processing_required);
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         assert!(!frame.readonly);
         frame.process_write(&mut *ctx).unwrap();
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         frame.finalize_response().unwrap();
         mreq.parse_ok(response.as_slice()).unwrap();
         for i in 100..100 + coils.len() {
@@ -304,10 +304,10 @@ fn test_nostd_client() {
         frame.parse().unwrap();
         assert!(frame.response_required);
         assert!(frame.processing_required);
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         assert!(frame.readonly);
         frame.process_read(&*ctx).unwrap();
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         frame.finalize_response().unwrap();
         let mut result_mem = alloc_stack!([bool; 256]);
         let mut result = FixedVec::new(&mut result_mem);

--- a/src/tests/test_std.rs
+++ b/src/tests/test_std.rs
@@ -1,5 +1,6 @@
 #[allow(clippy::wildcard_imports)]
 use crate::client::*;
+use crate::consts::{ModbusErrorCode, ModbusFunction};
 use crate::server::context::ModbusContext;
 use crate::server::storage::{ModbusStorageFull, FULL_STORAGE_SIZE as STORAGE_SIZE};
 #[allow(clippy::wildcard_imports)]
@@ -697,9 +698,9 @@ fn test_std_frame_fc01_fc02_fc03_fc04_unknown_function() {
     assert!(frame.readonly);
     assert_eq!(frame.count, 5);
     assert_eq!(frame.reg, 5);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     frame.process_read(&*ctx).unwrap();
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
 
@@ -711,9 +712,9 @@ fn test_std_frame_fc01_fc02_fc03_fc04_unknown_function() {
     assert!(frame.readonly);
     assert_eq!(frame.count, 5);
     assert_eq!(frame.reg, 5);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     frame.process_read(&*ctx).unwrap();
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
     // check rtu crc error
@@ -731,7 +732,7 @@ fn test_std_frame_fc01_fc02_fc03_fc04_unknown_function() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(!frame.processing_required);
-    assert_eq!(frame.error, 1);
+    assert_eq!(frame.error, Some(ModbusErrorCode::IllegalFunction));
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
 
@@ -740,7 +741,7 @@ fn test_std_frame_fc01_fc02_fc03_fc04_unknown_function() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(!frame.processing_required);
-    assert_eq!(frame.error, 1);
+    assert_eq!(frame.error, Some(ModbusErrorCode::IllegalFunction));
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
     // check context oob
@@ -751,9 +752,9 @@ fn test_std_frame_fc01_fc02_fc03_fc04_unknown_function() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     frame.process_read(&*ctx).unwrap();
-    assert_eq!(frame.error, 2);
+    assert_eq!(frame.error, Some(ModbusErrorCode::IllegalDataAddress));
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
     let framebuf = gen_rtu_frame(&request);
@@ -761,9 +762,9 @@ fn test_std_frame_fc01_fc02_fc03_fc04_unknown_function() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     frame.process_read(&*ctx).unwrap();
-    assert_eq!(frame.error, 2);
+    assert_eq!(frame.error, Some(ModbusErrorCode::IllegalDataAddress));
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
     // check invalid length
@@ -807,7 +808,7 @@ fn test_std_frame_fc01_fc02_fc03_fc04_unknown_function() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(frame.readonly);
     frame.process_read(&*ctx).unwrap();
     frame.finalize_response().unwrap();
@@ -829,7 +830,7 @@ fn test_std_frame_fc01_fc02_fc03_fc04_unknown_function() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(frame.readonly);
     frame.process_read(&*ctx).unwrap();
     frame.finalize_response().unwrap();
@@ -839,7 +840,7 @@ fn test_std_frame_fc01_fc02_fc03_fc04_unknown_function() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(frame.readonly);
     frame.process_read(&*ctx).unwrap();
     frame.finalize_response().unwrap();
@@ -853,7 +854,7 @@ fn test_std_frame_fc01_fc02_fc03_fc04_unknown_function() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(frame.readonly);
     frame.process_read(&*ctx).unwrap();
     frame.finalize_response().unwrap();
@@ -877,10 +878,10 @@ fn test_std_frame_fc05_fc06() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(!frame.readonly);
     frame.process_write(&mut *ctx).unwrap();
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
     assert!(ctx.get_coil(11).unwrap());
@@ -889,10 +890,10 @@ fn test_std_frame_fc05_fc06() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(!frame.readonly);
     frame.process_write(&mut *ctx).unwrap();
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
     // write coil broadcast tcp
@@ -902,10 +903,10 @@ fn test_std_frame_fc05_fc06() {
     frame.parse().unwrap();
     assert!(!frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(!frame.readonly);
     frame.process_write(&mut *ctx).unwrap();
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(ctx.get_coil(5).unwrap());
     let request = [0, 5, 0, 0x7, 0xff, 0];
     let framebuf = gen_rtu_frame(&request);
@@ -913,10 +914,10 @@ fn test_std_frame_fc05_fc06() {
     frame.parse().unwrap();
     assert!(!frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(!frame.readonly);
     frame.process_write(&mut *ctx).unwrap();
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(ctx.get_coil(7).unwrap());
     // write coil invalid data
     let request = [1, 5, 0, 0xb, 0xff, 1];
@@ -926,10 +927,10 @@ fn test_std_frame_fc05_fc06() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(!frame.readonly);
     frame.process_write(&mut *ctx).unwrap();
-    assert_eq!(frame.error, 3);
+    assert_eq!(frame.error, Some(ModbusErrorCode::IllegalDataValue));
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
     // write coil context oob
@@ -940,10 +941,10 @@ fn test_std_frame_fc05_fc06() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(!frame.readonly);
     frame.process_write(&mut *ctx).unwrap();
-    assert_eq!(frame.error, 2);
+    assert_eq!(frame.error, Some(ModbusErrorCode::IllegalDataAddress));
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
     let framebuf = gen_rtu_frame(&request);
@@ -951,7 +952,7 @@ fn test_std_frame_fc05_fc06() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(!frame.readonly);
     frame.process_write(&mut *ctx).unwrap();
     frame.finalize_response().unwrap();
@@ -964,10 +965,10 @@ fn test_std_frame_fc05_fc06() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(!frame.readonly);
     frame.process_write(&mut *ctx).unwrap();
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
     assert_eq!(ctx.get_holding(12).unwrap(), 0x3355);
@@ -976,10 +977,10 @@ fn test_std_frame_fc05_fc06() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(!frame.readonly);
     frame.process_write(&mut *ctx).unwrap();
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
     // write holding context oob
@@ -990,10 +991,10 @@ fn test_std_frame_fc05_fc06() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(!frame.readonly);
     frame.process_write(&mut *ctx).unwrap();
-    assert_eq!(frame.error, 2);
+    assert_eq!(frame.error, Some(ModbusErrorCode::IllegalDataAddress));
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
     let framebuf = gen_rtu_frame(&request);
@@ -1001,10 +1002,10 @@ fn test_std_frame_fc05_fc06() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(!frame.readonly);
     frame.process_write(&mut *ctx).unwrap();
-    assert_eq!(frame.error, 2);
+    assert_eq!(frame.error, Some(ModbusErrorCode::IllegalDataAddress));
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
 }
@@ -1022,10 +1023,10 @@ fn test_std_frame_fc15() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(!frame.readonly);
     frame.process_write(&mut *ctx).unwrap();
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
     assert!(ctx.get_coil(305).unwrap());
@@ -1039,10 +1040,10 @@ fn test_std_frame_fc15() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(!frame.readonly);
     frame.process_write(&mut *ctx).unwrap();
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
     // write coils context oob
@@ -1053,10 +1054,10 @@ fn test_std_frame_fc15() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(!frame.readonly);
     frame.process_write(&mut *ctx).unwrap();
-    assert_eq!(frame.error, 2);
+    assert_eq!(frame.error, Some(ModbusErrorCode::IllegalDataAddress));
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
     let framebuf = gen_rtu_frame(&request);
@@ -1064,10 +1065,10 @@ fn test_std_frame_fc15() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(!frame.readonly);
     frame.process_write(&mut *ctx).unwrap();
-    assert_eq!(frame.error, 2);
+    assert_eq!(frame.error, Some(ModbusErrorCode::IllegalDataAddress));
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
 }
@@ -1085,13 +1086,13 @@ fn test_std_frame_fc16() {
     let framebuf = gen_tcp_frame(&request);
     let mut frame = ModbusFrame::new(1, &framebuf, ModbusProto::TcpUdp, &mut result);
     frame.parse().unwrap();
-    assert_eq!(frame.func, 0x10);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.func, ModbusFunction::SetHoldingsBulk);
+    assert_eq!(frame.error, None);
     assert!(frame.response_required);
     assert!(frame.processing_required);
     assert!(!frame.readonly);
     frame.process_write(&mut *ctx).unwrap();
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
     assert_eq!(ctx.get_holding(300).unwrap(), 0x1122);
@@ -1103,10 +1104,10 @@ fn test_std_frame_fc16() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(!frame.readonly);
     frame.process_write(&mut *ctx).unwrap();
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
     // write holdings context oob
@@ -1119,10 +1120,10 @@ fn test_std_frame_fc16() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(!frame.readonly);
     frame.process_write(&mut *ctx).unwrap();
-    assert_eq!(frame.error, 2);
+    assert_eq!(frame.error, Some(ModbusErrorCode::IllegalDataAddress));
     frame.finalize_response().unwrap();
     assert_eq!(result.as_slice(), response);
     let framebuf = gen_rtu_frame(&request);
@@ -1130,10 +1131,10 @@ fn test_std_frame_fc16() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(!frame.readonly);
     frame.process_write(&mut *ctx).unwrap();
-    assert_eq!(frame.error, 2);
+    assert_eq!(frame.error, Some(ModbusErrorCode::IllegalDataAddress));
     frame.finalize_response().unwrap();
     check_rtu_response(&result, &response);
 }
@@ -1156,10 +1157,10 @@ fn test_modbus_ascii() {
     frame.parse().unwrap();
     assert!(frame.response_required);
     assert!(frame.processing_required);
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     assert!(frame.readonly);
     frame.process_read(&ctx).unwrap();
-    assert_eq!(frame.error, 0);
+    assert_eq!(frame.error, None);
     frame.finalize_response().unwrap();
     generate_ascii_frame(result.as_slice(), &mut ascii_result).unwrap();
     assert_eq!(ascii_result.as_slice(), response);
@@ -1200,10 +1201,10 @@ fn test_std_client() {
         frame.parse().unwrap();
         assert!(frame.response_required);
         assert!(frame.processing_required);
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         assert!(!frame.readonly);
         frame.process_write(&mut *ctx).unwrap();
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         frame.finalize_response().unwrap();
         mreq.parse_ok(&response).unwrap();
         for i in 100..100 + coils.len() {
@@ -1234,10 +1235,10 @@ fn test_std_client() {
         frame.parse().unwrap();
         assert!(frame.response_required);
         assert!(frame.processing_required);
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         assert!(frame.readonly);
         frame.process_read(&*ctx).unwrap();
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         frame.finalize_response().unwrap();
         let mut result = Vec::new();
         mreq.parse_bool(&response, &mut result).unwrap();
@@ -1270,10 +1271,10 @@ fn test_std_client() {
         frame.parse().unwrap();
         assert!(frame.response_required);
         assert!(frame.processing_required);
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         assert!(frame.readonly);
         frame.process_read(&*ctx).unwrap();
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         frame.finalize_response().unwrap();
         let mut result = Vec::new();
         mreq.parse_bool(&response, &mut result).unwrap();
@@ -1301,10 +1302,10 @@ fn test_std_client() {
         frame.parse().unwrap();
         assert!(frame.response_required);
         assert!(frame.processing_required);
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         assert!(!frame.readonly);
         frame.process_write(&mut *ctx).unwrap();
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         frame.finalize_response().unwrap();
         mreq.parse_ok(&response).unwrap();
         assert!(ctx.get_coil(100).unwrap());
@@ -1329,10 +1330,10 @@ fn test_std_client() {
         frame.parse().unwrap();
         assert!(frame.response_required);
         assert!(frame.processing_required);
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         assert!(!frame.readonly);
         frame.process_write(&mut *ctx).unwrap();
-        assert_eq!(frame.error, 2);
+        assert_eq!(frame.error, Some(ModbusErrorCode::IllegalDataAddress));
         frame.finalize_response().unwrap();
         assert_eq!(
             mreq.parse_ok(&response).err().unwrap(),
@@ -1361,10 +1362,10 @@ fn test_std_client() {
         frame.parse().unwrap();
         assert!(frame.response_required);
         assert!(frame.processing_required);
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         assert!(!frame.readonly);
         frame.process_write(&mut *ctx).unwrap();
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         frame.finalize_response().unwrap();
         mreq.parse_ok(&response).unwrap();
         for i in 100..100 + holdings.len() {
@@ -1395,10 +1396,10 @@ fn test_std_client() {
         frame.parse().unwrap();
         assert!(frame.response_required);
         assert!(frame.processing_required);
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         assert!(frame.readonly);
         frame.process_read(&*ctx).unwrap();
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         frame.finalize_response().unwrap();
         let mut result = Vec::new();
         mreq.parse_u16(&response, &mut result).unwrap();
@@ -1426,10 +1427,10 @@ fn test_std_client() {
         frame.parse().unwrap();
         assert!(frame.response_required);
         assert!(frame.processing_required);
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         assert!(!frame.readonly);
         frame.process_write(&mut *ctx).unwrap();
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         frame.finalize_response().unwrap();
         mreq.parse_ok(&response).unwrap();
 
@@ -1454,10 +1455,10 @@ fn test_std_client() {
         frame.parse().unwrap();
         assert!(frame.response_required);
         assert!(frame.processing_required);
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         assert!(frame.readonly);
         frame.process_read(&*ctx).unwrap();
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         frame.finalize_response().unwrap();
         let mut result = String::new();
         mreq.parse_string(&response, &mut result).unwrap();
@@ -1490,10 +1491,10 @@ fn test_std_client() {
         frame.parse().unwrap();
         assert!(frame.response_required);
         assert!(frame.processing_required);
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         assert!(frame.readonly);
         frame.process_read(&*ctx).unwrap();
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         frame.finalize_response().unwrap();
         let mut result = Vec::new();
         mreq.parse_u16(&response, &mut result).unwrap();
@@ -1521,10 +1522,10 @@ fn test_std_client() {
         frame.parse().unwrap();
         assert!(frame.response_required);
         assert!(frame.processing_required);
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         assert!(!frame.readonly);
         frame.process_write(&mut *ctx).unwrap();
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         frame.finalize_response().unwrap();
         mreq.parse_ok(&response).unwrap();
         assert!(ctx.get_coil(100).unwrap());
@@ -1550,10 +1551,10 @@ fn test_std_client() {
         frame.parse().unwrap();
         assert!(frame.response_required);
         assert!(frame.processing_required);
-        assert_eq!(frame.error, 0);
+        assert_eq!(frame.error, None);
         assert!(!frame.readonly);
         frame.process_write(&mut *ctx).unwrap();
-        assert_eq!(frame.error, 2);
+        assert_eq!(frame.error, Some(ModbusErrorCode::IllegalDataAddress));
         frame.finalize_response().unwrap();
         assert_eq!(
             mreq.parse_ok(&response).err().unwrap(),


### PR DESCRIPTION
Closes #45.

I also took the liberty of applying some small clippy lints and using `VectorTrait::extend()` instead of `for d in data { VectorTrait::push(d)`