### PR TITLE
Restore `std` and remove `heapless` from default features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 ## Changelog
 
+### v0.12.1
+
+* Restore `std` and remove `heapless` from default features 
+
 ### v0.12
 
 * Bump Rust version to 1.86
 * Bump `heapless` to 0.9.1
+* Make `heapless` a default feature and remove `std` 
 
 ### v0.11
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmodbus"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Serhij S. <div@altertech.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -30,8 +30,7 @@ bincode = { version = "2.0.0-rc.2", optional = true }
 defmt = { version = "0.3.0", optional = true }
 
 [features]
-# default = ["std"]
-default = ["heapless"]
+default = ["std"]
 std = []
 with_serde = ["serde", "serde_arrays"]
 with_bincode = ["bincode"]


### PR DESCRIPTION
This was an oopsie in #48 when I was testing