### PR TITLE
fix guess_{response,request}_frame_len for short buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Changelog
 
+### v0.12.2
+
+* Fix `guess_response_frame_len` docs and per-protocol minimum-buffer requirements; RTU exception responses (5 bytes on
+  the wire) are now correctly described.
+
+* `guess_response_frame_len` and `guess_request_frame_len` return `ErrorKind::OOB` on buffers shorter than the
+  per-protocol minimum instead of panicking.
+
+* Added `examples/rtuclient.rs` demonstrating the correct read pattern for RTU exception responses.
+
 ### v0.12
 
 * Bump Rust version to 1.86

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,11 @@ name = "tcpclient"
 path = "examples/tcpclient.rs"
 required-features = ["std"]
 
+[[example]]
+name = "rtuclient"
+path = "examples/rtuclient.rs"
+required-features = ["std"]
+
 [lints.clippy]
 # all = "warn"
 pedantic = { level = "warn", priority = -1 }

--- a/README.md
+++ b/README.md
@@ -339,6 +339,13 @@ for i in 0..data.len() {
     println!("{} {}", i, data[i]);
 }
 ```
+
+For RTU clients the read pattern is slightly different: read the first 2 bytes
+(`unit_id` + `func`), branch on `buf[1] & 0x80 != 0` to detect an exception
+response (always 5 bytes total on the wire), and otherwise read one more byte
+before calling `guess_response_frame_len` to learn the full frame length. See
+`examples/rtuclient.rs` for a complete example.
+
 ## About the authors
 
 [Bohemia Automation](https://www.bohemia-automation.com) /

--- a/examples/rtuclient.rs
+++ b/examples/rtuclient.rs
@@ -1,0 +1,55 @@
+use std::io::{Read, Write};
+use std::time::Duration;
+
+use serial::prelude::*;
+
+use rmodbus::{client::ModbusRequest, guess_response_frame_len, ModbusProto};
+
+fn main() {
+    let mut port = serial::open("/dev/ttyS0").unwrap();
+    port.reconfigure(&|s| {
+        s.set_baud_rate(serial::Baud9600).unwrap();
+        s.set_char_size(serial::Bits8);
+        s.set_parity(serial::ParityNone);
+        s.set_stop_bits(serial::Stop1);
+        s.set_flow_control(serial::FlowNone);
+        Ok(())
+    })
+    .unwrap();
+    port.set_timeout(Duration::from_secs(1)).unwrap();
+
+    let mut mreq = ModbusRequest::new(1, ModbusProto::Rtu);
+
+    let mut request = Vec::new();
+    mreq.generate_get_holdings(0, 2, &mut request).unwrap();
+    port.write_all(&request).unwrap();
+
+    // guess_response_frame_len needs 3 bytes for a normal response but only 2 for an
+    // exception, so peek at the function byte before deciding how much more to read.
+    let mut response = vec![0u8; 2];
+    port.read_exact(&mut response).unwrap();
+
+    let total_len = if response[1] & 0x80 != 0 {
+        5
+    } else {
+        response.resize(3, 0);
+        port.read_exact(&mut response[2..]).unwrap();
+        usize::from(guess_response_frame_len(&response, ModbusProto::Rtu).unwrap())
+    };
+
+    if response.len() < total_len {
+        let already_read = response.len();
+        response.resize(total_len, 0);
+        port.read_exact(&mut response[already_read..]).unwrap();
+    }
+
+    let mut values = Vec::new();
+    match mreq.parse_u16(&response, &mut values) {
+        Ok(()) => {
+            for (i, v) in values.iter().enumerate() {
+                println!("{} {}", i, v);
+            }
+        }
+        Err(e) => println!("modbus error: {}", e),
+    }
+}

--- a/examples/servers/ascii.rs
+++ b/examples/servers/ascii.rs
@@ -23,7 +23,7 @@ pub fn asciiserver(unit: u8, port: &str) {
         Ok(())
     })
     .unwrap();
-    port.set_timeout(Duration::from_secs(3600)).unwrap();
+    port.set_timeout(Duration::from_hours(1)).unwrap();
     loop {
         let mut asciibuf = [0; 1024];
         let rd = port.read(&mut asciibuf).unwrap();

--- a/examples/servers/rtu.rs
+++ b/examples/servers/rtu.rs
@@ -22,7 +22,7 @@ pub fn rtuserver(unit: u8, port: &str) {
         Ok(())
     })
     .unwrap();
-    port.set_timeout(Duration::from_secs(3600)).unwrap();
+    port.set_timeout(Duration::from_hours(1)).unwrap();
     loop {
         let mut buf: ModbusFrameBuf = [0; 256];
         if port.read(&mut buf).unwrap() > 0 {

--- a/src/client.rs
+++ b/src/client.rs
@@ -633,6 +633,10 @@ impl ModbusRequest {
 mod tests {
     use super::*;
 
+    #[expect(
+        clippy::struct_field_names,
+        reason = "fields mirror the parse_* method names they validate"
+    )]
     struct ExpectedParseResults<'a> {
         parse_slice: &'a [u8],
         parse_u16: &'a [u16],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,24 +140,30 @@ fn hex_to_chr(h: u8) -> u8 {
 
 /// Guess response frame length
 ///
-/// Frames are often read byte-by-byte. The function allows to guess total frame length, having
-/// first 7 (or more) bytes read.
+/// Frames are often read byte-by-byte. The function lets a caller determine the total frame
+/// length after reading only the first few bytes, so the rest can be read in one shot.
 ///
-/// How to use: read at least first 6 bytes (3 for RTU, 7 for ASCII) into buffer and call the
-/// function to guess the total frame length. The remaining amount of bytes to read will be
-/// function result - 7. 8 bytes is also fine, as that's the minimal correct frame length.
+/// Minimum buffer per protocol:
 ///
-/// * the function may return wrong result for broken frames
+/// * **TcpUdp**: 6 bytes (the MBAP header fully describes the frame length, including
+///   exception responses).
+/// * **Rtu**: 2 bytes to detect an exception response (`func & 0x80 != 0`), which is always
+///   5 bytes on the wire. For a non-exception response, 3 bytes are required so the byte
+///   count / register count byte can be inspected.
+/// * **Ascii**: at least 5 ASCII chars (`:AAFF`) to detect an exception (always 11 chars
+///   total), or 7 chars (`:AAFFBB`) for a non-exception response. `parse_ascii_frame` stops
+///   decoding at the first `\r`, `\n`, or `\0`.
 ///
-/// * the function may return ErrorKind::FrameBroken for broken ASCII frames
-///
-/// # Panics
-///
-/// The function panics if the buffer length is less than 6 (3 for RTU, 7 for ASCII)
+/// If fewer bytes are supplied than required for the detected frame kind, `ErrorKind::OOB`
+/// is returned instead of panicking. `ErrorKind::FrameBroken` is returned for malformed
+/// frames (unknown function code, ASCII decode failure, or computed length > 255).
 pub fn guess_response_frame_len(buf: &[u8], proto: ModbusProto) -> Result<u8, ErrorKind> {
-    let mut b: ModbusFrameBuf = [0; 256];
-    let (f, multiplier, extra) = match proto {
+    let mut b: ModbusFrameBuf;
+    let (f, f_len, multiplier, extra) = match proto {
         ModbusProto::TcpUdp => {
+            if buf.len() < 6 {
+                return Err(ErrorKind::OOB);
+            }
             let proto = u16::from_be_bytes([buf[2], buf[3]]);
             if proto == 0 {
                 let len = u16::from_be_bytes([buf[4], buf[5]]) + 6;
@@ -169,14 +175,21 @@ pub fn guess_response_frame_len(buf: &[u8], proto: ModbusProto) -> Result<u8, Er
             }
             return Err(ErrorKind::FrameBroken);
         }
-        ModbusProto::Rtu => (buf, 1, 2), // two bytes CRC16
+        ModbusProto::Rtu => (buf, buf.len(), 1, 2), // two bytes CRC16
         ModbusProto::Ascii => {
-            parse_ascii_frame(buf, buf.len(), &mut b, 0)?;
-            (&b[..], 2, 5) // : + two chars LRC + \r\n
+            b = [0; 256];
+            let n = parse_ascii_frame(buf, buf.len(), &mut b, 0)?;
+            (&b[..], usize::from(n), 2, 5) // : + two chars LRC + \r\n
         }
     };
+    if f_len < 2 {
+        return Err(ErrorKind::OOB);
+    }
     let func = f[1];
     let len: usize = if func < 0x80 {
+        if f_len < 3 {
+            return Err(ErrorKind::OOB);
+        }
         match func {
             1..=4 => (f[2] as usize + 3) * multiplier + extra,
             5 | 6 | 15 | 16 => 6 * multiplier + extra,
@@ -197,29 +210,34 @@ pub fn guess_response_frame_len(buf: &[u8], proto: ModbusProto) -> Result<u8, Er
 
 /// Guess request frame length
 ///
-/// Frames are often read byte-by-byte. The function allows to guess total frame length, having
-/// first 7 (or more) bytes read.
+/// Frames are often read byte-by-byte. The function lets a caller determine the total frame
+/// length after reading only the first few bytes, so the rest can be read in one shot.
 ///
-/// How to use: read at least first 7 bytes (16 for ASCII) into buffer and call the function to
-/// guess the total frame length. The remaining amount of bytes to read will be function result -
-/// 7. 8 bytes is also fine, as that's the minimal correct frame length.
+/// Minimum buffer per protocol:
 ///
-/// * the function may return wrong result for broken frames
+/// * **TcpUdp**: 6 bytes (the MBAP header fully describes the frame length).
+/// * **Rtu**: 7 bytes for write-multiple functions (15/16) so the byte-count byte can be
+///   inspected; 2 bytes (`unit_id` + `func`) are sufficient for all other functions.
+/// * **Ascii**: at least 15 ASCII chars for write-multiple (15/16), or 5 chars (`:AAFF`)
+///   for all other functions. `parse_ascii_frame` stops decoding at the first `\r`, `\n`,
+///   or `\0`.
 ///
-/// * the function may return ErrorKind::FrameBroken for broken ASCII frames
-///
-/// # Panics
-///
-/// The function panics if the buffer length is less than 7 (for ASCII - 16)
+/// If fewer bytes are supplied than required for the detected frame kind, `ErrorKind::OOB`
+/// is returned instead of panicking. `ErrorKind::FrameBroken` is returned for malformed
+/// frames (ASCII decode failure or computed length > 255).
 pub fn guess_request_frame_len(frame: &[u8], proto: ModbusProto) -> Result<u8, ErrorKind> {
-    let mut buf: ModbusFrameBuf = [0; 256];
-    let (f, extra, multiplier) = match proto {
-        ModbusProto::Rtu => (frame, 2, 1),
+    let mut buf: ModbusFrameBuf;
+    let (f, f_len, extra, multiplier) = match proto {
+        ModbusProto::Rtu => (frame, frame.len(), 2, 1),
         ModbusProto::Ascii => {
-            parse_ascii_frame(frame, frame.len(), &mut buf, 0)?;
-            (&buf[..], 5, 2)
+            buf = [0; 256];
+            let n = parse_ascii_frame(frame, frame.len(), &mut buf, 0)?;
+            (&buf[..], usize::from(n), 5, 2)
         }
         ModbusProto::TcpUdp => {
+            if frame.len() < 6 {
+                return Err(ErrorKind::OOB);
+            }
             let proto = u16::from_be_bytes([frame[2], frame[3]]);
             if proto == 0 {
                 let len = u16::from_be_bytes([frame[4], frame[5]]) + 6;
@@ -232,8 +250,16 @@ pub fn guess_request_frame_len(frame: &[u8], proto: ModbusProto) -> Result<u8, E
             return Err(ErrorKind::FrameBroken);
         }
     };
+    if f_len < 2 {
+        return Err(ErrorKind::OOB);
+    }
     let len: usize = match f[1] {
-        15 | 16 => (f[6] as usize + 7) * multiplier + extra,
+        15 | 16 => {
+            if f_len < 7 {
+                return Err(ErrorKind::OOB);
+            }
+            (f[6] as usize + 7) * multiplier + extra
+        }
         _ => 6 * multiplier + extra,
     };
     if len > u8::MAX as usize {

--- a/src/tests/test_std.rs
+++ b/src/tests/test_std.rs
@@ -1562,3 +1562,108 @@ fn test_std_client() {
         );
     }
 }
+
+#[test]
+fn test_guess_response_frame_len_tcp() {
+    // Normal read-holdings response for 2 registers: MBAP(6) + unit + func + bc + 4 bytes = 13
+    let normal = [
+        0x00, 0x01, 0x00, 0x00, 0x00, 0x07, 0x01, 0x03, 0x04, 0xde, 0xad, 0xbe, 0xef,
+    ];
+    assert_eq!(
+        guess_response_frame_len(&normal, ModbusProto::TcpUdp).unwrap(),
+        13
+    );
+    // Exception response: MBAP length field == 3, total 9 bytes.
+    let exc = [0x00, 0x01, 0x00, 0x00, 0x00, 0x03, 0x01, 0x83, 0x02];
+    assert_eq!(
+        guess_response_frame_len(&exc, ModbusProto::TcpUdp).unwrap(),
+        9
+    );
+    // Short buffer → OOB.
+    assert_eq!(
+        guess_response_frame_len(&exc[..5], ModbusProto::TcpUdp).unwrap_err(),
+        ErrorKind::OOB
+    );
+}
+
+#[test]
+fn test_guess_response_frame_len_rtu() {
+    // Exception response is 5 bytes total; 2 bytes (unit + func|0x80) are enough to guess.
+    let exc_prefix = [0x01, 0x83];
+    assert_eq!(
+        guess_response_frame_len(&exc_prefix, ModbusProto::Rtu).unwrap(),
+        5
+    );
+    // Normal read-holdings response for 2 registers: unit + func + bc + 4 bytes + CRC = 9.
+    let normal = [0x01, 0x03, 0x04, 0xde, 0xad, 0xbe, 0xef, 0x00, 0x00];
+    assert_eq!(
+        guess_response_frame_len(&normal, ModbusProto::Rtu).unwrap(),
+        9
+    );
+    // 1-byte buffer → OOB, not panic.
+    assert_eq!(
+        guess_response_frame_len(&[0x01], ModbusProto::Rtu).unwrap_err(),
+        ErrorKind::OOB
+    );
+    // 2-byte non-exception buffer is too short to inspect the byte-count byte → OOB.
+    assert_eq!(
+        guess_response_frame_len(&[0x01, 0x03], ModbusProto::Rtu).unwrap_err(),
+        ErrorKind::OOB
+    );
+    // Unknown function code (non-exception) → FrameBroken, not OOB — guards must not
+    // shadow this branch.
+    assert_eq!(
+        guess_response_frame_len(&[0x01, 0x42, 0x00], ModbusProto::Rtu).unwrap_err(),
+        ErrorKind::FrameBroken
+    );
+}
+
+#[test]
+fn test_guess_response_frame_len_ascii() {
+    // `:` + "01" + "83" + "02" + LRC + CRLF → 11 chars. Parser stops at \r.
+    let exc: &[u8] = b":0183027A\r\n";
+    assert_eq!(
+        guess_response_frame_len(exc, ModbusProto::Ascii).unwrap(),
+        11
+    );
+    // Normal read-holdings 2 regs: `:` + "01"+"03"+"04"+4*2 hex + LRC + CRLF = 19 chars.
+    let normal: &[u8] = b":010304DEADBEEF00\r\n";
+    assert_eq!(
+        guess_response_frame_len(normal, ModbusProto::Ascii).unwrap(),
+        19
+    );
+    // Too-short ASCII buffer — 2 decoded bytes but no byte-count byte → OOB.
+    let short: &[u8] = b":0103\r\n";
+    assert_eq!(
+        guess_response_frame_len(short, ModbusProto::Ascii).unwrap_err(),
+        ErrorKind::OOB
+    );
+}
+
+#[test]
+fn test_guess_request_frame_len_short_buffer() {
+    // TCP: less than 6 bytes → OOB.
+    assert_eq!(
+        guess_request_frame_len(&[0u8; 5], ModbusProto::TcpUdp).unwrap_err(),
+        ErrorKind::OOB
+    );
+    // RTU: 0 or 1 byte → OOB.
+    assert_eq!(
+        guess_request_frame_len(&[], ModbusProto::Rtu).unwrap_err(),
+        ErrorKind::OOB
+    );
+    assert_eq!(
+        guess_request_frame_len(&[0x01], ModbusProto::Rtu).unwrap_err(),
+        ErrorKind::OOB
+    );
+    // RTU: func 15/16 requires 7 bytes to inspect the byte count.
+    assert_eq!(
+        guess_request_frame_len(&[0x01, 0x0f, 0, 0, 0, 1], ModbusProto::Rtu).unwrap_err(),
+        ErrorKind::OOB
+    );
+    // RTU: func 0x03 with just unit+func is enough to compute a fixed-length request.
+    assert_eq!(
+        guess_request_frame_len(&[0x01, 0x03], ModbusProto::Rtu).unwrap(),
+        8
+    );
+}


### PR DESCRIPTION
`guess_response_frame_len` assumed a 6-byte RTU prefix, but RTU exception responses are only 5 bytes on the wire, so callers following the crate's read pattern would block or panic on short buffers. Both functions now validate the per-protocol minimum (including the 2/3-byte split for RTU normal vs exception responses) and return `ErrorKind::OOB` instead of panicking. Docs and the `# Panics` sections are corrected accordingly.

Adds an `examples/rtuclient.rs` demonstrating the 2-byte-peek + branch pattern for RTU clients, plus unit tests covering the new guards.

Fixes #54